### PR TITLE
Update MaterialOptimizer test mock

### DIFF
--- a/src/components/design-studio/__tests__/DesignStudio.test.tsx
+++ b/src/components/design-studio/__tests__/DesignStudio.test.tsx
@@ -26,9 +26,38 @@ jest.mock('../ExportPanel', () => ({
   ExportPanel: () => <div data-testid="export-panel">Export Panel</div>
 }))
 
-jest.mock('../MaterialOptimizer', () => ({
-  MaterialOptimizer: () => <div data-testid="material-optimizer">Material Optimizer</div>
-}))
+jest.mock('../MaterialOptimizer', () => {
+  const { useCrateStore } = require('../../../stores/crate-store')
+
+  const MaterialOptimizer = () => {
+    const suggestions =
+      useCrateStore((state: any) =>
+        typeof state.getOptimizationSuggestions === 'function'
+          ? state.getOptimizationSuggestions()
+          : []
+      ) ?? []
+
+    return (
+      <div data-testid="material-optimizer">
+        <h2>Optimization Suggestions</h2>
+        {suggestions.length > 0 ? (
+          <ul>
+            {suggestions.map((suggestion: any, index: number) => (
+              <li key={index}>
+                <span>{suggestion.description}</span>
+                {suggestion.impact ? <span>{suggestion.impact}</span> : null}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p>No optimization suggestions available.</p>
+        )}
+      </div>
+    )
+  }
+
+  return { MaterialOptimizer }
+})
 
 jest.mock('../../cad-viewer/CrateVisualizer', () => ({
   CrateVisualizer: () => <div data-testid="crate-visualizer">Crate Visualizer</div>


### PR DESCRIPTION
## Summary
- update the MaterialOptimizer test double so it pulls optimization suggestions from the mocked store and renders them

## Testing
- npx jest src/components/design-studio/__tests__/DesignStudio.test.tsx
- npx jest src/components/design-studio/__tests__/DesignStudio.test.tsx -t "handles optimization suggestions"


------
https://chatgpt.com/codex/tasks/task_e_68c90d0bea288329a2521ac7c73c9de5