### PR TITLE
feat: show component metadata on hover

### DIFF
--- a/src/components/cad-viewer/ComponentMetadata.tsx
+++ b/src/components/cad-viewer/ComponentMetadata.tsx
@@ -1,432 +1,137 @@
 'use client'
 
-import { useMemo, useState, useRef, useEffect } from 'react'
+import { useMemo } from 'react'
 import { Html } from '@react-three/drei'
-import { CrateConfiguration, CrateDimensions } from '@/types/crate'
-import { generateBillOfMaterials, calculateMaterialEfficiency, calculateCrateWeight } from '@/lib/domain/calculations'
+import type { ComponentInfo } from './componentMetadata'
 
 interface ComponentMetadataProps {
-  config: CrateConfiguration
-  dimensions: CrateDimensions
+  components: ComponentInfo[]
   showMetadata: boolean
+  hoveredComponentId: string | null
+  pointerPosition: { x: number; y: number } | null
 }
 
-interface ComponentInfo {
-  id: string
-  name: string
-  type: 'panel' | 'skid' | 'product' | 'clearance' | 'overall'
-  position: [number, number, number]
-  dimensions: {
-    length: number
-    width: number
-    height: number
-  }
-  material?: {
-    type: string
-    grade: string
-    thickness?: number
-  }
-  weight?: number
-  cost?: number
-  specifications: string[]
-  manufacturingNotes: string[]
-}
+export function ComponentMetadata({
+  components,
+  showMetadata,
+  hoveredComponentId,
+  pointerPosition
+}: ComponentMetadataProps) {
+  const componentMap = useMemo(() => {
+    const map = new Map<string, ComponentInfo>()
+    components.forEach(component => {
+      map.set(component.id, component)
+    })
+    return map
+  }, [components])
 
-export function ComponentMetadata({ config, dimensions, showMetadata }: ComponentMetadataProps) {
-  const [hoveredComponent, setHoveredComponent] = useState<string | null>(null)
-  const [mousePosition, setMousePosition] = useState<[number, number]>([0, 0])
-  const timeoutRef = useRef<NodeJS.Timeout>()
-
-  // Generate component metadata
-  const components = useMemo((): ComponentInfo[] => {
-    if (!showMetadata) return []
-    
-    const bom = generateBillOfMaterials(config)
-    const efficiency = calculateMaterialEfficiency(config)
-    const weight = calculateCrateWeight(config)
-    
-    return [
-      // Product component
-      {
-        id: 'product',
-        name: 'Product',
-        type: 'product',
-        position: [0, config.product.height / 2, 0] as [number, number, number],
-        dimensions: {
-          length: config.product.length,
-          width: config.product.width,
-          height: config.product.height
-        },
-        weight: config.product.weight,
-        specifications: [
-          `Dimensions: ${config.product.length}" × ${config.product.width}" × ${config.product.height}"`,
-          `Weight: ${config.product.weight} lbs`,
-          `Center of Gravity: X:${config.product.centerOfGravity.x}", Y:${config.product.centerOfGravity.y}", Z:${config.product.centerOfGravity.z}"`,
-          `Handling Requirements: ${config.product.weight > 1000 ? 'Heavy lift equipment required' : 'Standard handling'}`
-        ],
-        manufacturingNotes: [
-          'Product must be centered in crate',
-          'Center of gravity must be within acceptable limits',
-          'Protective padding required around product'
-        ]
-      },
-      
-      // Bottom panel
-      {
-        id: 'bottom-panel',
-        name: 'Bottom Panel',
-        type: 'panel',
-        position: [0, -dimensions.overallHeight / 2 + config.materials.plywood.thickness / 2, 0] as [number, number, number],
-        dimensions: {
-          length: dimensions.overallLength,
-          width: dimensions.overallWidth,
-          height: config.materials.plywood.thickness
-        },
-        material: {
-          type: 'Plywood',
-          grade: config.materials.plywood.grade,
-          thickness: config.materials.plywood.thickness
-        },
-        weight: dimensions.overallLength * dimensions.overallWidth * config.materials.plywood.thickness * 0.02, // Approximate
-        cost: bom.items.find(item => item.description.includes('Bottom'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.plywood.grade} Plywood`,
-          `Thickness: ${config.materials.plywood.thickness}"`,
-          `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallWidth}"`,
-          `Weight: ${(dimensions.overallLength * dimensions.overallWidth * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Must support full product weight',
-          'Edge banding required for durability',
-          'Moisture-resistant treatment recommended'
-        ]
-      },
-      
-      // Side panels
-      {
-        id: 'side-panel-1',
-        name: 'Side Panel (Left)',
-        type: 'panel',
-        position: [-dimensions.overallWidth / 2 + config.materials.plywood.thickness / 2, 0, 0] as [number, number, number],
-        dimensions: {
-          length: dimensions.overallLength,
-          width: config.materials.plywood.thickness,
-          height: dimensions.overallHeight
-        },
-        material: {
-          type: 'Plywood',
-          grade: config.materials.plywood.grade,
-          thickness: config.materials.plywood.thickness
-        },
-        weight: dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
-        cost: bom.items.find(item => item.description.includes('Side'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.plywood.grade} Plywood`,
-          `Thickness: ${config.materials.plywood.thickness}"`,
-          `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallHeight}"`,
-          `Weight: ${(dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Reinforcement at corners required',
-          'Ventilation holes may be needed',
-          'Smooth finish for product protection'
-        ]
-      },
-      
-      {
-        id: 'side-panel-2',
-        name: 'Side Panel (Right)',
-        type: 'panel',
-        position: [dimensions.overallWidth / 2 - config.materials.plywood.thickness / 2, 0, 0] as [number, number, number],
-        dimensions: {
-          length: dimensions.overallLength,
-          width: config.materials.plywood.thickness,
-          height: dimensions.overallHeight
-        },
-        material: {
-          type: 'Plywood',
-          grade: config.materials.plywood.grade,
-          thickness: config.materials.plywood.thickness
-        },
-        weight: dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
-        cost: bom.items.find(item => item.description.includes('Side'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.plywood.grade} Plywood`,
-          `Thickness: ${config.materials.plywood.thickness}"`,
-          `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallHeight}"`,
-          `Weight: ${(dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Reinforcement at corners required',
-          'Ventilation holes may be needed',
-          'Smooth finish for product protection'
-        ]
-      },
-      
-      // End panels
-      {
-        id: 'end-panel-1',
-        name: 'End Panel (Front)',
-        type: 'panel',
-        position: [0, 0, dimensions.overallLength / 2 - config.materials.plywood.thickness / 2] as [number, number, number],
-        dimensions: {
-          length: config.materials.plywood.thickness,
-          width: dimensions.overallWidth,
-          height: dimensions.overallHeight
-        },
-        material: {
-          type: 'Plywood',
-          grade: config.materials.plywood.grade,
-          thickness: config.materials.plywood.thickness
-        },
-        weight: dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
-        cost: bom.items.find(item => item.description.includes('End'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.plywood.grade} Plywood`,
-          `Thickness: ${config.materials.plywood.thickness}"`,
-          `Dimensions: ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
-          `Weight: ${(dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Access panel for loading/unloading',
-          'Reinforced corners for durability',
-          'Weather-resistant finish required'
-        ]
-      },
-      
-      {
-        id: 'end-panel-2',
-        name: 'End Panel (Back)',
-        type: 'panel',
-        position: [0, 0, -dimensions.overallLength / 2 + config.materials.plywood.thickness / 2] as [number, number, number],
-        dimensions: {
-          length: config.materials.plywood.thickness,
-          width: dimensions.overallWidth,
-          height: dimensions.overallHeight
-        },
-        material: {
-          type: 'Plywood',
-          grade: config.materials.plywood.grade,
-          thickness: config.materials.plywood.thickness
-        },
-        weight: dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
-        cost: bom.items.find(item => item.description.includes('End'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.plywood.grade} Plywood`,
-          `Thickness: ${config.materials.plywood.thickness}"`,
-          `Dimensions: ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
-          `Weight: ${(dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Access panel for loading/unloading',
-          'Reinforced corners for durability',
-          'Weather-resistant finish required'
-        ]
-      },
-      
-      // Skids
-      {
-        id: 'skids',
-        name: 'Skids',
-        type: 'skid',
-        position: [0, -dimensions.overallHeight / 2 - config.materials.lumber.thickness / 2, 0] as [number, number, number],
-        dimensions: {
-          length: dimensions.overallLength + config.skids.overhang.front + config.skids.overhang.back,
-          width: config.materials.lumber.width,
-          height: config.materials.lumber.thickness
-        },
-        material: {
-          type: 'Lumber',
-          grade: config.materials.lumber.grade,
-          thickness: config.materials.lumber.thickness
-        },
-        weight: config.skids.count * (dimensions.overallLength + config.skids.overhang.front + config.skids.overhang.back) * config.materials.lumber.width * config.materials.lumber.thickness * 0.02,
-        cost: bom.items.find(item => item.description.includes('Skid'))?.cost || 0,
-        specifications: [
-          `Material: ${config.materials.lumber.grade} Lumber`,
-          `Count: ${config.skids.count} pieces`,
-          `Pitch: ${config.skids.pitch}"`,
-          `Overhang: Front ${config.skids.overhang.front}", Back ${config.skids.overhang.back}"`,
-          `Weight: ${(config.skids.count * (dimensions.overallLength + config.skids.overhang.front + config.skids.overhang.back) * config.materials.lumber.width * config.materials.lumber.thickness * 0.02).toFixed(1)} lbs`
-        ],
-        manufacturingNotes: [
-          'Must support full crate weight',
-          'Forklift access required',
-          'Weather-resistant treatment',
-          'Proper spacing for ventilation'
-        ]
-      },
-      
-      // Overall crate
-      {
-        id: 'overall-crate',
-        name: 'Complete Crate',
-        type: 'overall',
-        position: [0, 0, 0] as [number, number, number],
-        dimensions: {
-          length: dimensions.overallLength,
-          width: dimensions.overallWidth,
-          height: dimensions.overallHeight
-        },
-        weight: weight,
-        cost: bom.totalCost,
-        specifications: [
-          `Overall Dimensions: ${dimensions.overallLength}" × ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
-          `Total Weight: ${weight.toFixed(0)} lbs`,
-          `Material Cost: $${bom.totalCost.toFixed(2)}`,
-          `Material Efficiency: ${efficiency.toFixed(1)}%`,
-          `Applied Materials Standard: AMAT-0251-70054`
-        ],
-        manufacturingNotes: [
-          'All components must meet Applied Materials specifications',
-          'Quality inspection required before shipment',
-          'Proper labeling and documentation needed',
-          'Handling equipment requirements documented'
-        ]
-      }
-    ]
-  }, [config, dimensions, showMetadata])
-
-  const handleMouseEnter = (componentId: string) => {
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-    }
-    setHoveredComponent(componentId)
+  if (!showMetadata || !hoveredComponentId || !pointerPosition) {
+    return null
   }
 
-  const handleMouseLeave = () => {
-    timeoutRef.current = setTimeout(() => {
-      setHoveredComponent(null)
-    }, 100) // Small delay to prevent flickering
-  }
+  const component = componentMap.get(hoveredComponentId)
 
-  const handleMouseMove = (event: React.MouseEvent) => {
-    setMousePosition([event.clientX, event.clientY])
+  if (!component) {
+    return null
   }
-
-  if (!showMetadata) return null
 
   return (
-    <group>
-      {components.map((component) => (
-        <Html
-          key={component.id}
-          position={component.position}
-          center
-          distanceFactor={8}
-          zIndexRange={[100, 0]}
-        >
-          <div
-            className="relative"
-            onMouseEnter={() => handleMouseEnter(component.id)}
-            onMouseLeave={handleMouseLeave}
-            onMouseMove={handleMouseMove}
-          >
-            {/* Component indicator */}
-            <div 
-              className={`w-4 h-4 rounded-full border-2 transition-all duration-200 cursor-pointer ${
-                hoveredComponent === component.id 
-                  ? 'bg-blue-500 border-blue-600 scale-125' 
-                  : 'bg-blue-300 border-blue-400 hover:bg-blue-400'
-              }`}
-              style={{
-                backgroundColor: component.type === 'product' ? '#dc2626' :
-                                component.type === 'panel' ? '#059669' :
-                                component.type === 'skid' ? '#7c3aed' :
-                                component.type === 'overall' ? '#f59e0b' : '#6b7280'
-              }}
-              title={`Hover to see ${component.name} details`}
-            />
-            
-            {/* Metadata tooltip */}
-            {hoveredComponent === component.id && (
-              <div 
-                className="absolute top-6 left-1/2 transform -translate-x-1/2 bg-white border border-gray-300 rounded-lg shadow-xl p-4 min-w-80 max-w-96 z-50"
-                style={{
-                  position: 'fixed',
-                  top: mousePosition[1] + 10,
-                  left: mousePosition[0] + 10,
-                  transform: 'none'
-                }}
-              >
-                <div className="space-y-3">
-                  {/* Header */}
-                  <div className="border-b border-gray-200 pb-2">
-                    <h3 className="text-lg font-semibold text-gray-900">{component.name}</h3>
-                    <p className="text-sm text-gray-600 capitalize">{component.type} Component</p>
-                  </div>
-                  
-                  {/* Dimensions */}
-                  <div>
-                    <h4 className="text-sm font-medium text-gray-800 mb-1">Dimensions</h4>
-                    <p className="text-sm text-gray-600">
-                      {component.dimensions.length}" × {component.dimensions.width}" × {component.dimensions.height}"
-                    </p>
-                  </div>
-                  
-                  {/* Material info */}
-                  {component.material && (
-                    <div>
-                      <h4 className="text-sm font-medium text-gray-800 mb-1">Material</h4>
-                      <p className="text-sm text-gray-600">
-                        {component.material.type} - {component.material.grade}
-                        {component.material.thickness && ` (${component.material.thickness}")`}
-                      </p>
-                    </div>
+    <Html fullscreen zIndexRange={[1000, 0]}>
+      <div
+        className="pointer-events-none fixed z-50 min-w-64 max-w-md"
+        style={{
+          top: pointerPosition.y + 12,
+          left: pointerPosition.x + 12
+        }}
+        role="tooltip"
+        aria-live="polite"
+      >
+        <div className="rounded-lg border border-gray-200 bg-white/95 p-4 shadow-2xl backdrop-blur-sm">
+          <div className="border-b border-gray-200 pb-2">
+            <p className="text-xs uppercase tracking-wide text-slate-500">{formatComponentType(component.type)}</p>
+            <h3 className="text-lg font-semibold text-slate-900">{component.name}</h3>
+          </div>
+
+          <div className="mt-3 space-y-3 text-sm text-slate-700">
+            <div>
+              <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Dimensions</h4>
+              <p>
+                {component.dimensions.length}″ × {component.dimensions.width}″ × {component.dimensions.height}″
+              </p>
+            </div>
+
+            {component.material && (
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Material</h4>
+                <p>
+                  {component.material.type} — {component.material.grade}
+                  {component.material.thickness !== undefined && ` (${component.material.thickness}″)`}
+                </p>
+              </div>
+            )}
+
+            {(component.weight || component.cost) && (
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Properties</h4>
+                <ul className="space-y-1">
+                  {component.weight !== undefined && (
+                    <li>Weight: {component.weight.toFixed(1)} lbs</li>
                   )}
-                  
-                  {/* Weight and cost */}
-                  {(component.weight || component.cost) && (
-                    <div>
-                      <h4 className="text-sm font-medium text-gray-800 mb-1">Properties</h4>
-                      <div className="text-sm text-gray-600 space-y-1">
-                        {component.weight && <p>Weight: {component.weight.toFixed(1)} lbs</p>}
-                        {component.cost && <p>Cost: ${component.cost.toFixed(2)}</p>}
-                      </div>
-                    </div>
+                  {component.cost !== undefined && component.cost > 0 && (
+                    <li>Cost: ${component.cost.toFixed(2)}</li>
                   )}
-                  
-                  {/* Specifications */}
-                  <div>
-                    <h4 className="text-sm font-medium text-gray-800 mb-1">Specifications</h4>
-                    <ul className="text-sm text-gray-600 space-y-1">
-                      {component.specifications.slice(0, 3).map((spec, index) => (
-                        <li key={index} className="flex items-start">
-                          <span className="text-blue-500 mr-2">•</span>
-                          {spec}
-                        </li>
-                      ))}
-                      {component.specifications.length > 3 && (
-                        <li className="text-xs text-gray-500">
-                          +{component.specifications.length - 3} more specifications
-                        </li>
-                      )}
-                    </ul>
-                  </div>
-                  
-                  {/* Manufacturing notes */}
-                  <div>
-                    <h4 className="text-sm font-medium text-gray-800 mb-1">Manufacturing Notes</h4>
-                    <ul className="text-sm text-gray-600 space-y-1">
-                      {component.manufacturingNotes.slice(0, 2).map((note, index) => (
-                        <li key={index} className="flex items-start">
-                          <span className="text-orange-500 mr-2">•</span>
-                          {note}
-                        </li>
-                      ))}
-                      {component.manufacturingNotes.length > 2 && (
-                        <li className="text-xs text-gray-500">
-                          +{component.manufacturingNotes.length - 2} more notes
-                        </li>
-                      )}
-                    </ul>
-                  </div>
-                </div>
+                </ul>
+              </div>
+            )}
+
+            {component.specifications.length > 0 && (
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Specifications</h4>
+                <ul className="space-y-1">
+                  {component.specifications.slice(0, 3).map((specification, index) => (
+                    <li key={index} className="flex gap-2">
+                      <span className="text-blue-500">•</span>
+                      <span>{specification}</span>
+                    </li>
+                  ))}
+                  {component.specifications.length > 3 && (
+                    <li className="text-xs text-slate-500">
+                      +{component.specifications.length - 3} additional specification(s)
+                    </li>
+                  )}
+                </ul>
+              </div>
+            )}
+
+            {component.manufacturingNotes.length > 0 && (
+              <div>
+                <h4 className="text-xs font-semibold uppercase tracking-wide text-slate-500">Manufacturing Notes</h4>
+                <ul className="space-y-1">
+                  {component.manufacturingNotes.slice(0, 2).map((note, index) => (
+                    <li key={index} className="flex gap-2">
+                      <span className="text-amber-500">•</span>
+                      <span>{note}</span>
+                    </li>
+                  ))}
+                  {component.manufacturingNotes.length > 2 && (
+                    <li className="text-xs text-slate-500">
+                      +{component.manufacturingNotes.length - 2} additional note(s)
+                    </li>
+                  )}
+                </ul>
               </div>
             )}
           </div>
-        </Html>
-      ))}
-    </group>
+        </div>
+      </div>
+    </Html>
   )
 }
+
+function formatComponentType(type: ComponentInfo['type']): string {
+  return type
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
+}
+

--- a/src/components/cad-viewer/CrateAssembly.tsx
+++ b/src/components/cad-viewer/CrateAssembly.tsx
@@ -1,21 +1,34 @@
 'use client'
 
 import { useMemo, memo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 import * as THREE from 'three'
 import { CrateConfiguration, CrateDimensions } from '@/types/crate'
 import { CratePanel } from './CratePanel'
 import { ProductModel } from './ProductModel'
 import { SkidModel } from './SkidModel'
 
+type ComponentPointerHandler = (componentId: string, event: ThreeEvent<PointerEvent>) => void
+
 interface CrateAssemblyProps {
   config: CrateConfiguration
   dimensions: CrateDimensions
   showExploded?: boolean
+  onComponentPointerOver?: ComponentPointerHandler
+  onComponentPointerMove?: ComponentPointerHandler
+  onComponentPointerOut?: ComponentPointerHandler
 }
 
-export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, showExploded = false }: CrateAssemblyProps) {
+export const CrateAssembly = memo(function CrateAssembly({
+  config,
+  dimensions,
+  showExploded = false,
+  onComponentPointerOver,
+  onComponentPointerMove,
+  onComponentPointerOut
+}: CrateAssemblyProps) {
   const explosionOffset = useMemo(() => showExploded ? 3 : 0, [showExploded])
-  
+
   return (
     <group>
       {/* Skids (bottom support) */}
@@ -24,11 +37,15 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
           key={index}
           length={config.product.length + config.skids.overhang.front + config.skids.overhang.back}
           position={[
-            0, 
-            -config.materials.plywood.thickness / 2 - explosionOffset * 0.5, 
+            0,
+            -config.materials.plywood.thickness / 2 - explosionOffset * 0.5,
             (index - (config.skids.count - 1) / 2) * config.skids.pitch
           ]}
           material={config.materials.lumber.grade}
+          metadataId="skids"
+          onPointerOver={onComponentPointerOver}
+          onPointerMove={onComponentPointerMove}
+          onPointerOut={onComponentPointerOut}
         />
       ))}
       
@@ -42,22 +59,34 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         }}
         position={[0, -explosionOffset, 0]}
         material={config.materials.plywood.grade}
+        metadataId="bottom-panel"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Bottom Frame (2x4 lumber around bottom panel) */}
       <CrateFrame
         dimensions={dimensions}
         position={[0, config.materials.plywood.thickness / 2, 0]}
         material={config.materials.lumber.grade}
+        metadataId="bottom-frame"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Corner Posts (4 vertical 2x4s) */}
       <CornerPosts
         dimensions={dimensions}
         height={dimensions.overallHeight}
         material={config.materials.lumber.grade}
+        metadataId="corner-posts"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Side Panels */}
       <CratePanel
         type="side"
@@ -69,8 +98,12 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         position={[-(dimensions.overallWidth / 2) - explosionOffset, dimensions.overallHeight / 2, 0]}
         rotation={[0, 0, Math.PI / 2]}
         material={config.materials.plywood.grade}
+        metadataId="side-panel-1"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       <CratePanel
         type="side"
         dimensions={{
@@ -81,8 +114,12 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         position={[(dimensions.overallWidth / 2) + explosionOffset, dimensions.overallHeight / 2, 0]}
         rotation={[0, 0, -Math.PI / 2]}
         material={config.materials.plywood.grade}
+        metadataId="side-panel-2"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* End Panels */}
       <CratePanel
         type="end"
@@ -94,8 +131,12 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         position={[0, dimensions.overallHeight / 2, -(dimensions.overallLength / 2) - explosionOffset]}
         rotation={[0, Math.PI / 2, 0]}
         material={config.materials.plywood.grade}
+        metadataId="end-panel-1"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       <CratePanel
         type="end"
         dimensions={{
@@ -106,15 +147,23 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         position={[0, dimensions.overallHeight / 2, (dimensions.overallLength / 2) + explosionOffset]}
         rotation={[0, -Math.PI / 2, 0]}
         material={config.materials.plywood.grade}
+        metadataId="end-panel-2"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Top Frame (2x4 lumber around top) */}
       <CrateFrame
         dimensions={dimensions}
         position={[0, dimensions.overallHeight - config.materials.plywood.thickness / 2 + explosionOffset, 0]}
         material={config.materials.lumber.grade}
+        metadataId="top-frame"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Top Panel */}
       <CratePanel
         type="top"
@@ -125,54 +174,94 @@ export const CrateAssembly = memo(function CrateAssembly({ config, dimensions, s
         }}
         position={[0, dimensions.overallHeight + explosionOffset, 0]}
         material={config.materials.plywood.grade}
+        metadataId="top-panel"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
-      
+
       {/* Product Model */}
       <ProductModel
         product={config.product}
         position={[0, config.product.height / 2, 0]}
         showExploded={showExploded}
+        metadataId="product"
+        onPointerOver={onComponentPointerOver}
+        onPointerMove={onComponentPointerMove}
+        onPointerOut={onComponentPointerOut}
       />
     </group>
   )
 })
 
 // Crate Frame Component (2x4 lumber framing) - Optimized with instanced rendering
-const CrateFrame = memo(function CrateFrame({ 
-  dimensions, 
-  position, 
-  material
-}: { 
+const CrateFrame = memo(function CrateFrame({
+  dimensions,
+  position,
+  material,
+  metadataId,
+  onPointerOver,
+  onPointerMove,
+  onPointerOut
+}: {
   dimensions: CrateDimensions
   position: [number, number, number]
   material: string
+  metadataId?: string
+  onPointerOver?: ComponentPointerHandler
+  onPointerMove?: ComponentPointerHandler
+  onPointerOut?: ComponentPointerHandler
 }) {
   const frameColor = getLumberColor(material)
   const frameThickness = 1.5 // 2x4 actual thickness
   const frameHeight = 3.5 // 2x4 actual height
-  
-  // Memoize geometry and material for better performance
-  const geometry = useMemo(() => new THREE.BoxGeometry(), [])
-  const material_mesh = useMemo(() => new THREE.MeshLambertMaterial({ color: frameColor }), [frameColor])
-  
+
   return (
     <group position={position}>
       {/* Front and back rails */}
-      <mesh position={[0, 0, dimensions.overallLength / 2]} castShadow receiveShadow>
+      <mesh
+        position={[0, 0, dimensions.overallLength / 2]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[dimensions.overallWidth, frameHeight, frameThickness]} />
         <meshLambertMaterial color={frameColor} />
       </mesh>
-      <mesh position={[0, 0, -dimensions.overallLength / 2]} castShadow receiveShadow>
+      <mesh
+        position={[0, 0, -dimensions.overallLength / 2]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[dimensions.overallWidth, frameHeight, frameThickness]} />
         <meshLambertMaterial color={frameColor} />
       </mesh>
-      
+
       {/* Left and right rails */}
-      <mesh position={[dimensions.overallWidth / 2, 0, 0]} castShadow receiveShadow>
+      <mesh
+        position={[dimensions.overallWidth / 2, 0, 0]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[frameThickness, frameHeight, dimensions.overallLength]} />
         <meshLambertMaterial color={frameColor} />
       </mesh>
-      <mesh position={[-dimensions.overallWidth / 2, 0, 0]} castShadow receiveShadow>
+      <mesh
+        position={[-dimensions.overallWidth / 2, 0, 0]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[frameThickness, frameHeight, dimensions.overallLength]} />
         <meshLambertMaterial color={frameColor} />
       </mesh>
@@ -181,18 +270,26 @@ const CrateFrame = memo(function CrateFrame({
 })
 
 // Corner Posts Component (4 vertical 2x4s) - Optimized with instanced rendering
-const CornerPosts = memo(function CornerPosts({ 
-  dimensions, 
-  height, 
-  material
-}: { 
+const CornerPosts = memo(function CornerPosts({
+  dimensions,
+  height,
+  material,
+  metadataId,
+  onPointerOver,
+  onPointerMove,
+  onPointerOut
+}: {
   dimensions: CrateDimensions
   height: number
   material: string
+  metadataId?: string
+  onPointerOver?: ComponentPointerHandler
+  onPointerMove?: ComponentPointerHandler
+  onPointerOut?: ComponentPointerHandler
 }) {
   const frameColor = getLumberColor(material)
   const frameThickness = 1.5 // 2x4 actual thickness
-  
+
   // Memoize corner positions
   const cornerPositions = useMemo((): [number, number, number][] => [
     [-dimensions.overallWidth / 2, height / 2, -dimensions.overallLength / 2],
@@ -208,7 +305,17 @@ const CornerPosts = memo(function CornerPosts({
   return (
     <group>
       {cornerPositions.map((position, index) => (
-        <mesh key={index} position={position} castShadow receiveShadow geometry={geometry} material={material_mesh} />
+        <mesh
+          key={index}
+          position={position}
+          castShadow
+          receiveShadow
+          geometry={geometry}
+          material={material_mesh}
+          onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+          onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+          onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+        />
       ))}
     </group>
   )

--- a/src/components/cad-viewer/CratePanel.tsx
+++ b/src/components/cad-viewer/CratePanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 
 interface CratePanelProps {
   type: 'bottom' | 'top' | 'side' | 'end'
@@ -12,20 +13,36 @@ interface CratePanelProps {
   position: [number, number, number]
   rotation?: [number, number, number]
   material: string
+  metadataId?: string
+  onPointerOver?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerMove?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerOut?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
 }
 
-export function CratePanel({ 
-  dimensions, 
-  position, 
+export function CratePanel({
+  dimensions,
+  position,
   rotation = [0, 0, 0],
-  material 
+  material,
+  metadataId,
+  onPointerOver,
+  onPointerMove,
+  onPointerOut
 }: CratePanelProps) {
   const materialColor = useMemo(() => getMaterialColor(material), [material])
-  
+
   return (
-    <mesh position={position} rotation={rotation} castShadow receiveShadow>
+    <mesh
+      position={position}
+      rotation={rotation}
+      castShadow
+      receiveShadow
+      onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+      onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+      onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+    >
       <boxGeometry args={[dimensions.width, dimensions.thickness, dimensions.length]} />
-      <meshLambertMaterial 
+      <meshLambertMaterial
         color={materialColor}
         transparent
         opacity={0.8}

--- a/src/components/cad-viewer/ProductModel.tsx
+++ b/src/components/cad-viewer/ProductModel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 
 interface ProductModelProps {
   product: {
@@ -16,26 +17,41 @@ interface ProductModelProps {
   }
   position: [number, number, number]
   showExploded?: boolean
+  metadataId?: string
+  onPointerOver?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerMove?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerOut?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
 }
 
-export function ProductModel({ product, position, showExploded = false }: ProductModelProps) {
+export function ProductModel({
+  product,
+  position,
+  showExploded = false,
+  metadataId,
+  onPointerOver,
+  onPointerMove,
+  onPointerOut
+}: ProductModelProps) {
   const explosionOffset = useMemo(() => showExploded ? 2 : 0, [showExploded])
-  
+
   // More realistic product color - industrial gray
   const color = useMemo(() => {
     return '#708090' // Slate gray - typical industrial equipment color
   }, [])
-  
+
   return (
     <group position={position}>
       {/* Main product body */}
-      <mesh 
+      <mesh
         position={[0, explosionOffset, 0]}
-        castShadow 
+        castShadow
         receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
       >
         <boxGeometry args={[product.width, product.height, product.length]} />
-        <meshLambertMaterial 
+        <meshLambertMaterial
           color={color}
           transparent
           opacity={0.9}
@@ -43,12 +59,15 @@ export function ProductModel({ product, position, showExploded = false }: Produc
       </mesh>
       
       {/* Center of gravity indicator (small red dot) */}
-      <mesh 
+      <mesh
         position={[
           product.centerOfGravity.x - product.width / 2,
           product.centerOfGravity.y + explosionOffset,
           product.centerOfGravity.z - product.length / 2
         ]}
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
       >
         <sphereGeometry args={[0.1, 8, 6]} />
         <meshLambertMaterial color="#FF0000" />

--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -1,36 +1,66 @@
 'use client'
 
 import { useMemo } from 'react'
+import type { ThreeEvent } from '@react-three/fiber'
 
 interface SkidModelProps {
   length: number
   position: [number, number, number]
   material: string
+  metadataId?: string
+  onPointerOver?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerMove?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
+  onPointerOut?: (componentId: string, event: ThreeEvent<PointerEvent>) => void
 }
 
-export function SkidModel({ length, position, material }: SkidModelProps) {
+export function SkidModel({
+  length,
+  position,
+  material,
+  metadataId,
+  onPointerOver,
+  onPointerMove,
+  onPointerOut
+}: SkidModelProps) {
   const skidColor = useMemo(() => getSkidColor(material), [material])
-  
+
   return (
     <group position={position}>
       {/* Skid runners (2 pieces) - 4x4 lumber */}
-      <mesh position={[-1.75, 0, 0]} castShadow receiveShadow>
+      <mesh
+        position={[-1.75, 0, 0]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[3.5, 3.5, length]} />
         <meshLambertMaterial color={skidColor} />
       </mesh>
-      
-      <mesh position={[1.75, 0, 0]} castShadow receiveShadow>
+
+      <mesh
+        position={[1.75, 0, 0]}
+        castShadow
+        receiveShadow
+        onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+        onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+        onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
+      >
         <boxGeometry args={[3.5, 3.5, length]} />
         <meshLambertMaterial color={skidColor} />
       </mesh>
-      
+
       {/* Cross members (every 16 inches) - 2x4 lumber */}
       {Array.from({ length: Math.floor(length / 16) + 1 }, (_, index) => (
-        <mesh 
+        <mesh
           key={index}
-          position={[0, 1.75, (index * 16) - length / 2]} 
-          castShadow 
+          position={[0, 1.75, (index * 16) - length / 2]}
+          castShadow
           receiveShadow
+          onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
+          onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
+          onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
         >
           <boxGeometry args={[7, 1.5, 3.5]} />
           <meshLambertMaterial color={skidColor} />

--- a/src/components/cad-viewer/componentMetadata.ts
+++ b/src/components/cad-viewer/componentMetadata.ts
@@ -1,0 +1,384 @@
+import { CrateConfiguration, CrateDimensions } from '@/types/crate'
+import { generateBillOfMaterials, calculateMaterialEfficiency, calculateCrateWeight } from '@/lib/domain/calculations'
+
+export type ComponentType =
+  | 'panel'
+  | 'skid'
+  | 'product'
+  | 'clearance'
+  | 'overall'
+  | 'frame'
+  | 'support'
+
+export interface ComponentInfo {
+  id: string
+  name: string
+  type: ComponentType
+  position: [number, number, number]
+  dimensions: {
+    length: number
+    width: number
+    height: number
+  }
+  material?: {
+    type: string
+    grade: string
+    thickness?: number
+  }
+  weight?: number
+  cost?: number
+  specifications: string[]
+  manufacturingNotes: string[]
+}
+
+export function generateComponentMetadata(
+  config: CrateConfiguration,
+  dimensions: CrateDimensions
+): ComponentInfo[] {
+  const bom = generateBillOfMaterials(config)
+  const efficiency = calculateMaterialEfficiency(config)
+  const weight = calculateCrateWeight(config)
+
+  const frameThickness = 1.5
+  const frameHeight = 3.5
+
+  return [
+    {
+      id: 'product',
+      name: 'Product',
+      type: 'product',
+      position: [0, config.product.height / 2, 0],
+      dimensions: {
+        length: config.product.length,
+        width: config.product.width,
+        height: config.product.height
+      },
+      weight: config.product.weight,
+      specifications: [
+        `Dimensions: ${config.product.length}" × ${config.product.width}" × ${config.product.height}"`,
+        `Weight: ${config.product.weight} lbs`,
+        `Center of Gravity: X:${config.product.centerOfGravity.x}", Y:${config.product.centerOfGravity.y}", Z:${config.product.centerOfGravity.z}"`,
+        `Handling Requirements: ${config.product.weight > 1000 ? 'Heavy lift equipment required' : 'Standard handling'}`
+      ],
+      manufacturingNotes: [
+        'Product must be centered in crate',
+        'Center of gravity must be within acceptable limits',
+        'Protective padding required around product'
+      ]
+    },
+    {
+      id: 'bottom-panel',
+      name: 'Bottom Panel',
+      type: 'panel',
+      position: [0, -dimensions.overallHeight / 2 + config.materials.plywood.thickness / 2, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: dimensions.overallWidth,
+        height: config.materials.plywood.thickness
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallLength * dimensions.overallWidth * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('Bottom'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallWidth}"`,
+        `Weight: ${(dimensions.overallLength * dimensions.overallWidth * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
+      ],
+      manufacturingNotes: [
+        'Must support full product weight',
+        'Edge banding required for durability',
+        'Moisture-resistant treatment recommended'
+      ]
+    },
+    {
+      id: 'top-panel',
+      name: 'Top Panel',
+      type: 'panel',
+      position: [0, dimensions.overallHeight + config.materials.plywood.thickness / 2, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: dimensions.overallWidth,
+        height: config.materials.plywood.thickness
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallLength * dimensions.overallWidth * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('Top'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallWidth}"`,
+        'Designed for removable access'
+      ],
+      manufacturingNotes: [
+        'Secure with screws or clamps for shipping',
+        'Weather seal required for outdoor storage',
+        'Verify clearance for lifting points'
+      ]
+    },
+    {
+      id: 'side-panel-1',
+      name: 'Side Panel (Left)',
+      type: 'panel',
+      position: [-dimensions.overallWidth / 2 + config.materials.plywood.thickness / 2, 0, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: config.materials.plywood.thickness,
+        height: dimensions.overallHeight
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('Side'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallHeight}"`,
+        `Weight: ${(dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
+      ],
+      manufacturingNotes: [
+        'Reinforcement at corners required',
+        'Ventilation holes may be needed',
+        'Smooth finish for product protection'
+      ]
+    },
+    {
+      id: 'side-panel-2',
+      name: 'Side Panel (Right)',
+      type: 'panel',
+      position: [dimensions.overallWidth / 2 - config.materials.plywood.thickness / 2, 0, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: config.materials.plywood.thickness,
+        height: dimensions.overallHeight
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('Side'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallLength}" × ${dimensions.overallHeight}"`,
+        `Weight: ${(dimensions.overallLength * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
+      ],
+      manufacturingNotes: [
+        'Reinforcement at corners required',
+        'Ventilation holes may be needed',
+        'Smooth finish for product protection'
+      ]
+    },
+    {
+      id: 'end-panel-1',
+      name: 'End Panel (Front)',
+      type: 'panel',
+      position: [0, 0, dimensions.overallLength / 2 - config.materials.plywood.thickness / 2],
+      dimensions: {
+        length: config.materials.plywood.thickness,
+        width: dimensions.overallWidth,
+        height: dimensions.overallHeight
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('End'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
+        `Weight: ${(dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
+      ],
+      manufacturingNotes: [
+        'Access panel for loading/unloading',
+        'Reinforced corners for durability',
+        'Weather-resistant finish required'
+      ]
+    },
+    {
+      id: 'end-panel-2',
+      name: 'End Panel (Back)',
+      type: 'panel',
+      position: [0, 0, -dimensions.overallLength / 2 + config.materials.plywood.thickness / 2],
+      dimensions: {
+        length: config.materials.plywood.thickness,
+        width: dimensions.overallWidth,
+        height: dimensions.overallHeight
+      },
+      material: {
+        type: 'Plywood',
+        grade: config.materials.plywood.grade,
+        thickness: config.materials.plywood.thickness
+      },
+      weight: dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02,
+      cost: bom.items.find(item => item.description.includes('End'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.plywood.grade} Plywood`,
+        `Thickness: ${config.materials.plywood.thickness}"`,
+        `Dimensions: ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
+        `Weight: ${(dimensions.overallWidth * dimensions.overallHeight * config.materials.plywood.thickness * 0.02).toFixed(1)} lbs`
+      ],
+      manufacturingNotes: [
+        'Access panel for loading/unloading',
+        'Reinforced corners for durability',
+        'Weather-resistant finish required'
+      ]
+    },
+    {
+      id: 'skids',
+      name: 'Skids',
+      type: 'skid',
+      position: [0, -dimensions.overallHeight / 2 - config.materials.lumber.thickness / 2, 0],
+      dimensions: {
+        length: dimensions.overallLength + config.skids.overhang.front + config.skids.overhang.back,
+        width: config.materials.lumber.width,
+        height: config.materials.lumber.thickness
+      },
+      material: {
+        type: 'Lumber',
+        grade: config.materials.lumber.grade,
+        thickness: config.materials.lumber.thickness
+      },
+      weight:
+        config.skids.count *
+        (dimensions.overallLength + config.skids.overhang.front + config.skids.overhang.back) *
+        config.materials.lumber.width *
+        config.materials.lumber.thickness *
+        0.02,
+      cost: bom.items.find(item => item.description.includes('Skid'))?.cost || 0,
+      specifications: [
+        `Material: ${config.materials.lumber.grade} Lumber`,
+        `Count: ${config.skids.count} pieces`,
+        `Pitch: ${config.skids.pitch}"`,
+        `Overhang: Front ${config.skids.overhang.front}", Back ${config.skids.overhang.back}"`
+      ],
+      manufacturingNotes: [
+        'Must support full crate weight',
+        'Forklift access required',
+        'Weather-resistant treatment',
+        'Proper spacing for ventilation'
+      ]
+    },
+    {
+      id: 'bottom-frame',
+      name: 'Bottom Frame',
+      type: 'frame',
+      position: [0, config.materials.plywood.thickness / 2, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: frameThickness,
+        height: frameHeight
+      },
+      material: {
+        type: 'Lumber',
+        grade: config.materials.lumber.grade,
+        thickness: frameThickness
+      },
+      specifications: [
+        'Constructed from standard 2×4 lumber',
+        `Perimeter length: ${(dimensions.overallWidth * 2 + dimensions.overallLength * 2).toFixed(0)}"`,
+        'Provides shear resistance for bottom assembly'
+      ],
+      manufacturingNotes: [
+        'Secure to bottom panel with lag screws',
+        'Ensure tight joints at corners',
+        'Apply structural adhesive for increased rigidity'
+      ]
+    },
+    {
+      id: 'top-frame',
+      name: 'Top Frame',
+      type: 'frame',
+      position: [0, dimensions.overallHeight - config.materials.plywood.thickness / 2, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: frameThickness,
+        height: frameHeight
+      },
+      material: {
+        type: 'Lumber',
+        grade: config.materials.lumber.grade,
+        thickness: frameThickness
+      },
+      specifications: [
+        'Constructed from standard 2×4 lumber',
+        `Perimeter length: ${(dimensions.overallWidth * 2 + dimensions.overallLength * 2).toFixed(0)}"`,
+        'Provides structural rigidity for top assembly'
+      ],
+      manufacturingNotes: [
+        'Secure to corner posts with lag screws',
+        'Verify squareness before panel installation',
+        'Seal joints to prevent moisture intrusion'
+      ]
+    },
+    {
+      id: 'corner-posts',
+      name: 'Corner Posts',
+      type: 'support',
+      position: [0, dimensions.overallHeight / 2, 0],
+      dimensions: {
+        length: dimensions.overallHeight,
+        width: frameThickness,
+        height: frameHeight
+      },
+      material: {
+        type: 'Lumber',
+        grade: config.materials.lumber.grade,
+        thickness: frameThickness
+      },
+      specifications: [
+        'Quantity: 4 posts',
+        `Height: ${dimensions.overallHeight}"`,
+        'Cross-section: 1.5" × 3.5"  (2×4 lumber)'
+      ],
+      manufacturingNotes: [
+        'Critical for load transfer to skids',
+        'Chamfer edges to prevent splintering',
+        'Pre-drill for lag screw connections'
+      ]
+    },
+    {
+      id: 'overall-crate',
+      name: 'Complete Crate',
+      type: 'overall',
+      position: [0, 0, 0],
+      dimensions: {
+        length: dimensions.overallLength,
+        width: dimensions.overallWidth,
+        height: dimensions.overallHeight
+      },
+      weight,
+      cost: bom.totalCost,
+      specifications: [
+        `Overall Dimensions: ${dimensions.overallLength}" × ${dimensions.overallWidth}" × ${dimensions.overallHeight}"`,
+        `Total Weight: ${weight.toFixed(0)} lbs`,
+        `Material Cost: $${bom.totalCost.toFixed(2)}`,
+        `Material Efficiency: ${efficiency.toFixed(1)}%`,
+        'Applied Materials Standard: AMAT-0251-70054'
+      ],
+      manufacturingNotes: [
+        'All components must meet Applied Materials specifications',
+        'Quality inspection required before shipment',
+        'Proper labeling and documentation needed',
+        'Handling equipment requirements documented'
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
## Summary
- centralize component metadata generation for panels, frames, skids, and the product
- convert the metadata UI into a pointer-following tooltip rendered when objects are hovered
- wire pointer handlers through the crate visualizer, assembly, and model meshes so hovering any object surfaces its metadata

## Testing
- npm run lint *(fails: repository already contains numerous lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68c90e6fb0308329981b2baeff50e329