### PR TITLE
Improve crate visual clarity and lighting

### DIFF
--- a/src/components/cad-viewer/CrateAssembly.tsx
+++ b/src/components/cad-viewer/CrateAssembly.tsx
@@ -7,6 +7,7 @@ import { CrateConfiguration, CrateDimensions } from '@/types/crate'
 import { CratePanel } from './CratePanel'
 import { ProductModel } from './ProductModel'
 import { SkidModel } from './SkidModel'
+import { adjustColor, getLumberColor } from './utils/materialColors'
 
 interface CrateAssemblyProps {
   config: CrateConfiguration
@@ -212,13 +213,13 @@ const CornerPosts = memo(function CornerPosts({
   
   // Memoize geometry and material
   const geometry = useMemo(() => new THREE.BoxGeometry(frameThickness, height, frameThickness), [frameThickness, height])
-  const material_mesh = useMemo(() => new THREE.MeshLambertMaterial({ color: frameColor }), [frameColor])
+  const material = useMemo(() => new THREE.MeshLambertMaterial({ color: frameColor }), [frameColor])
   const edgeColor = adjustColor(frameColor, -0.25)
 
   return (
     <group>
       {cornerPositions.map((position, index) => (
-        <mesh key={index} position={position} castShadow receiveShadow geometry={geometry} material={material_mesh}>
+        <mesh key={index} position={position} castShadow receiveShadow geometry={geometry} material={material}>
           <Edges color={edgeColor} threshold={25} />
         </mesh>
       ))}
@@ -226,39 +227,3 @@ const CornerPosts = memo(function CornerPosts({
   )
 })
 
-function getLumberColor(material: string): string {
-  const colors: Record<string, string> = {
-    'Standard': '#c8894c',
-    '#2': '#d79b63',
-    '#1': '#e8ae78',
-    'Select': '#f4c999'
-  }
-
-  return colors[material] || '#c8894c'
-}
-
-function adjustColor(hex: string, factor: number): string {
-  const normalized = hex.replace('#', '')
-  if (normalized.length !== 6) {
-    return hex
-  }
-
-  const num = parseInt(normalized, 16)
-  let r = (num >> 16) & 0xff
-  let g = (num >> 8) & 0xff
-  let b = num & 0xff
-
-  const adjust = (value: number) => {
-    if (factor >= 0) {
-      return Math.min(255, Math.round(value + (255 - value) * factor))
-    }
-
-    return Math.max(0, Math.round(value + value * factor))
-  }
-
-  r = adjust(r)
-  g = adjust(g)
-  b = adjust(b)
-
-  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
-}

--- a/src/components/cad-viewer/CrateAssembly.tsx
+++ b/src/components/cad-viewer/CrateAssembly.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, memo } from 'react'
 import * as THREE from 'three'
+import { Edges } from '@react-three/drei'
 import { CrateConfiguration, CrateDimensions } from '@/types/crate'
 import { CratePanel } from './CratePanel'
 import { ProductModel } from './ProductModel'
@@ -150,6 +151,7 @@ const CrateFrame = memo(function CrateFrame({
   const frameColor = getLumberColor(material)
   const frameThickness = 1.5 // 2x4 actual thickness
   const frameHeight = 3.5 // 2x4 actual height
+  const edgeColor = '#b37b44'
   
   // Memoize geometry and material for better performance
   const geometry = useMemo(() => new THREE.BoxGeometry(), [])
@@ -161,20 +163,24 @@ const CrateFrame = memo(function CrateFrame({
       <mesh position={[0, 0, dimensions.overallLength / 2]} castShadow receiveShadow>
         <boxGeometry args={[dimensions.overallWidth, frameHeight, frameThickness]} />
         <meshLambertMaterial color={frameColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
       <mesh position={[0, 0, -dimensions.overallLength / 2]} castShadow receiveShadow>
         <boxGeometry args={[dimensions.overallWidth, frameHeight, frameThickness]} />
         <meshLambertMaterial color={frameColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
-      
+
       {/* Left and right rails */}
       <mesh position={[dimensions.overallWidth / 2, 0, 0]} castShadow receiveShadow>
         <boxGeometry args={[frameThickness, frameHeight, dimensions.overallLength]} />
         <meshLambertMaterial color={frameColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
       <mesh position={[-dimensions.overallWidth / 2, 0, 0]} castShadow receiveShadow>
         <boxGeometry args={[frameThickness, frameHeight, dimensions.overallLength]} />
         <meshLambertMaterial color={frameColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
     </group>
   )
@@ -204,11 +210,14 @@ const CornerPosts = memo(function CornerPosts({
   // Memoize geometry and material
   const geometry = useMemo(() => new THREE.BoxGeometry(frameThickness, height, frameThickness), [frameThickness, height])
   const material_mesh = useMemo(() => new THREE.MeshLambertMaterial({ color: frameColor }), [frameColor])
-  
+  const edgeColor = '#b37b44'
+
   return (
     <group>
       {cornerPositions.map((position, index) => (
-        <mesh key={index} position={position} castShadow receiveShadow geometry={geometry} material={material_mesh} />
+        <mesh key={index} position={position} castShadow receiveShadow geometry={geometry} material={material_mesh}>
+          <Edges color={edgeColor} threshold={25} />
+        </mesh>
       ))}
     </group>
   )
@@ -216,11 +225,11 @@ const CornerPosts = memo(function CornerPosts({
 
 function getLumberColor(material: string): string {
   const colors: Record<string, string> = {
-    'Standard': '#8B4513', // Brown
-    '#2': '#A0522D',       // Sienna
-    '#1': '#D2691E',       // Chocolate
-    'Select': '#F4A460'    // Sandy Brown
+    'Standard': '#c8894c',
+    '#2': '#d79b63',
+    '#1': '#e8ae78',
+    'Select': '#f4c999'
   }
-  
-  return colors[material] || '#8B4513'
+
+  return colors[material] || '#c8894c'
 }

--- a/src/components/cad-viewer/CratePanel.tsx
+++ b/src/components/cad-viewer/CratePanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import { Edges } from '@react-three/drei'
 
 interface CratePanelProps {
   type: 'bottom' | 'top' | 'side' | 'end'
@@ -25,25 +26,26 @@ export function CratePanel({
   return (
     <mesh position={position} rotation={rotation} castShadow receiveShadow>
       <boxGeometry args={[dimensions.width, dimensions.thickness, dimensions.length]} />
-      <meshLambertMaterial 
+      <meshLambertMaterial
         color={materialColor}
         transparent
-        opacity={0.8}
+        opacity={0.92}
       />
+      <Edges color="#c6a46a" threshold={20} />
     </mesh>
   )
 }
 
 function getMaterialColor(material: string): string {
   const colors: Record<string, string> = {
-    'CDX': '#D2B48C', // Tan - realistic plywood color
-    'BC': '#DEB887',  // Burlywood - better plywood
-    'AC': '#F5DEB3',  // Wheat - high grade plywood
-    'Standard': '#8B4513', // Brown lumber
-    '#2': '#A0522D',  // Sienna lumber
-    '#1': '#D2691E',  // Chocolate lumber
-    'Select': '#F4A460' // Sandy brown lumber
+    'CDX': '#e6cc9f', // Warm tan plywood
+    'BC': '#eed7b0',  // Soft birch plywood
+    'AC': '#f6e7c9',  // Premium light plywood
+    'Standard': '#c8894c', // Updated lumber palette for clarity
+    '#2': '#d79b63',
+    '#1': '#e8ae78',
+    'Select': '#f4c999'
   }
-  
-  return colors[material] || '#D2B48C'
+
+  return colors[material] || '#e0c79c'
 }

--- a/src/components/cad-viewer/CratePanel.tsx
+++ b/src/components/cad-viewer/CratePanel.tsx
@@ -2,9 +2,10 @@
 
 import { useMemo } from 'react'
 import { Edges } from '@react-three/drei'
+import { adjustColor, getPanelColor, type CratePanelType } from './utils/materialColors'
 
 interface CratePanelProps {
-  type: 'bottom' | 'top' | 'side' | 'end'
+  type: CratePanelType
   dimensions: {
     width: number
     length: number
@@ -36,55 +37,5 @@ export function CratePanel({
       <Edges color={edgeColor} threshold={20} />
     </mesh>
   )
-}
-
-function getPanelColor(material: string, type: CratePanelProps['type']): string {
-  const materialPalette: Record<string, string> = {
-    'CDX': '#e6cc9f',
-    'BC': '#eed7b0',
-    'AC': '#f6e7c9',
-    'Marine': '#f1d9a6',
-    'OSB': '#d7b483',
-    'Standard': '#c8894c',
-    '#2': '#d79b63',
-    '#1': '#e8ae78',
-    'Select': '#f4c999'
-  }
-
-  const baseColor = materialPalette[material] || '#e0c79c'
-  const panelTone: Record<CratePanelProps['type'], number> = {
-    bottom: -0.12,
-    top: 0.06,
-    side: -0.04,
-    end: -0.08
-  }
-
-  return adjustColor(baseColor, panelTone[type])
-}
-
-function adjustColor(hex: string, factor: number): string {
-  const normalized = hex.replace('#', '')
-  if (normalized.length !== 6) {
-    return hex
-  }
-
-  const num = parseInt(normalized, 16)
-  let r = (num >> 16) & 0xff
-  let g = (num >> 8) & 0xff
-  let b = num & 0xff
-
-  const adjust = (value: number) => {
-    if (factor >= 0) {
-      return Math.min(255, Math.round(value + (255 - value) * factor))
-    }
-
-    return Math.max(0, Math.round(value + value * factor))
-  }
-
-  r = adjust(r)
-  g = adjust(g)
-  b = adjust(b)
-
-  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
 }
 

--- a/src/components/cad-viewer/CratePanel.tsx
+++ b/src/components/cad-viewer/CratePanel.tsx
@@ -15,13 +15,15 @@ interface CratePanelProps {
   material: string
 }
 
-export function CratePanel({ 
-  dimensions, 
-  position, 
+export function CratePanel({
+  type,
+  dimensions,
+  position,
   rotation = [0, 0, 0],
-  material 
+  material
 }: CratePanelProps) {
-  const materialColor = useMemo(() => getMaterialColor(material), [material])
+  const materialColor = useMemo(() => getPanelColor(material, type), [material, type])
+  const edgeColor = useMemo(() => adjustColor(materialColor, -0.35), [materialColor])
   
   return (
     <mesh position={position} rotation={rotation} castShadow receiveShadow>
@@ -31,21 +33,58 @@ export function CratePanel({
         transparent
         opacity={0.92}
       />
-      <Edges color="#c6a46a" threshold={20} />
+      <Edges color={edgeColor} threshold={20} />
     </mesh>
   )
 }
 
-function getMaterialColor(material: string): string {
-  const colors: Record<string, string> = {
-    'CDX': '#e6cc9f', // Warm tan plywood
-    'BC': '#eed7b0',  // Soft birch plywood
-    'AC': '#f6e7c9',  // Premium light plywood
-    'Standard': '#c8894c', // Updated lumber palette for clarity
+function getPanelColor(material: string, type: CratePanelProps['type']): string {
+  const materialPalette: Record<string, string> = {
+    'CDX': '#e6cc9f',
+    'BC': '#eed7b0',
+    'AC': '#f6e7c9',
+    'Marine': '#f1d9a6',
+    'OSB': '#d7b483',
+    'Standard': '#c8894c',
     '#2': '#d79b63',
     '#1': '#e8ae78',
     'Select': '#f4c999'
   }
 
-  return colors[material] || '#e0c79c'
+  const baseColor = materialPalette[material] || '#e0c79c'
+  const panelTone: Record<CratePanelProps['type'], number> = {
+    bottom: -0.12,
+    top: 0.06,
+    side: -0.04,
+    end: -0.08
+  }
+
+  return adjustColor(baseColor, panelTone[type])
 }
+
+function adjustColor(hex: string, factor: number): string {
+  const normalized = hex.replace('#', '')
+  if (normalized.length !== 6) {
+    return hex
+  }
+
+  const num = parseInt(normalized, 16)
+  let r = (num >> 16) & 0xff
+  let g = (num >> 8) & 0xff
+  let b = num & 0xff
+
+  const adjust = (value: number) => {
+    if (factor >= 0) {
+      return Math.min(255, Math.round(value + (255 - value) * factor))
+    }
+
+    return Math.max(0, Math.round(value + value * factor))
+  }
+
+  r = adjust(r)
+  g = adjust(g)
+  b = adjust(b)
+
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
+}
+

--- a/src/components/cad-viewer/CrateVisualizer.tsx
+++ b/src/components/cad-viewer/CrateVisualizer.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useMemo, useRef, useEffect, memo, lazy } from 'react'
 import { Canvas } from '@react-three/fiber'
-import { OrbitControls, Preload, Environment } from '@react-three/drei'
+import { OrbitControls, Preload, Environment, ContactShadows } from '@react-three/drei'
 import { OrbitControls as OrbitControlsImpl } from 'three-stdlib'
 import { CrateConfiguration } from '@/types/crate'
 import { calculateCrateDimensions } from '@/lib/domain/calculations'
@@ -106,7 +106,13 @@ export const CrateVisualizer = memo(function CrateVisualizer({
       controlsRef.current.saveState()
     }
   }, [cameraPosition, controlTarget])
-  
+
+  const backgroundColor = useMemo(() => (isMobile ? '#f7f9fc' : '#eef2fa'), [isMobile])
+  const fogSettings = useMemo(() => ({
+    near: isMobile ? 70 : 80,
+    far: isMobile ? 180 : 220
+  }), [isMobile])
+
   return (
     <div className={`${className} ${getMobileClasses()}`} role="img" aria-label="3D Crate Visualization" tabIndex={0}>
       <Canvas 
@@ -132,17 +138,17 @@ export const CrateVisualizer = memo(function CrateVisualizer({
         dpr={isMobile ? [1, 1.5] : [1, 2]} // Lower DPR on mobile for better performance
       >
         <Suspense fallback={<LoadingFallback />}>
-          <color attach="background" args={[isMobile ? '#f5f7fb' : '#eef1f7']} />
-          <fog attach="fog" args={[isMobile ? '#f5f7fb' : '#eef1f7', 80, 200]} />
+          <color attach="background" args={[backgroundColor]} />
+          <fog attach="fog" args={[backgroundColor, fogSettings.near, fogSettings.far]} />
           {/* Optimized professional lighting setup */}
-          <ambientLight intensity={isMobile ? 0.8 : 0.6} color={0xffffff} />
+          <ambientLight intensity={isMobile ? 0.75 : 0.65} color={0xffffff} />
           <hemisphereLight
-            intensity={isMobile ? 0.6 : 0.5}
-            args={[0xf5f3ea, 0x4f5d75, 0.6]}
+            intensity={isMobile ? 0.65 : 0.55}
+            args={[0xf2f6ff, 0x4f5d75, 0.65]}
           />
           <directionalLight
             position={[35, 40, 20]}
-            intensity={isMobile ? 1.25 : 1.6}
+            intensity={isMobile ? 1.2 : 1.45}
             castShadow={!isMobile} // Disable shadows on mobile
             shadow-mapSize={isMobile ? [1024, 1024] : [2048, 2048]} // Smaller shadow map on mobile
             shadow-camera-far={150}
@@ -153,11 +159,18 @@ export const CrateVisualizer = memo(function CrateVisualizer({
           />
           <directionalLight
             position={[-25, 25, -15]}
-            intensity={isMobile ? 0.5 : 0.75}
+            intensity={isMobile ? 0.45 : 0.7}
             color={0xfdf6ec}
           />
-          <pointLight position={[0, 18, 10]} intensity={isMobile ? 0.3 : 0.5} color={0xffffff} />
-          <Environment preset="city" background={false} />
+          <spotLight
+            position={[10, 45, 35]}
+            angle={0.4}
+            penumbra={0.5}
+            intensity={isMobile ? 0.35 : 0.55}
+            castShadow={!isMobile}
+          />
+          <pointLight position={[0, 22, 10]} intensity={isMobile ? 0.28 : 0.45} color={0xffffff} />
+          <Environment preset="apartment" background={false} />
           
           {/* CAD Model Components */}
           <CrateAssembly 
@@ -231,24 +244,34 @@ export const CrateVisualizer = memo(function CrateVisualizer({
           />
           
           {/* Professional grid and background */}
-          <gridHelper 
+          <gridHelper
             args={[
-              Math.max(dimensions.overallLength, dimensions.overallWidth) * 2, 
-              Math.max(dimensions.overallLength, dimensions.overallWidth) * 2, 
-              0xb5bcc9,
-              0x9aa3b5
-            ]} 
-            position={[0, -0.1, 0]} 
+              Math.max(dimensions.overallLength, dimensions.overallWidth) * 2,
+              Math.max(dimensions.overallLength, dimensions.overallWidth) * 2,
+              0xbfc6d6,
+              0xa5aec2
+            ]}
+            position={[0, -0.1, 0]}
+          />
+          <ContactShadows
+            rotation={[Math.PI / 2, 0, 0]}
+            position={[0, -0.99, 0]}
+            opacity={isMobile ? 0.45 : 0.6}
+            width={Math.max(dimensions.overallLength, dimensions.overallWidth) * 1.2}
+            height={Math.max(dimensions.overallLength, dimensions.overallWidth) * 1.2}
+            blur={isMobile ? 2.2 : 2.6}
+            far={25}
           />
           <mesh position={[0, -1, 0]} rotation={[-Math.PI / 2, 0, 0]} receiveShadow>
             <planeGeometry args={[
               Math.max(dimensions.overallLength, dimensions.overallWidth) * 3, 
               Math.max(dimensions.overallLength, dimensions.overallWidth) * 3
             ]} />
-            <meshLambertMaterial color={0xf6f6f8} />
+            <meshLambertMaterial color={0xf5f7fb} />
           </mesh>
         </Suspense>
       </Canvas>
     </div>
   )
 })
+

--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react'
 import { Edges } from '@react-three/drei'
+import { adjustColor, getSkidColor } from './utils/materialColors'
 
 interface SkidModelProps {
   length: number
@@ -43,42 +44,5 @@ export function SkidModel({ length, position, material }: SkidModelProps) {
       ))}
     </group>
   )
-}
-
-function getSkidColor(material: string): string {
-  const colors: Record<string, string> = {
-    'Standard': '#bc7e45',
-    '#2': '#cc9359',
-    '#1': '#ddaa70',
-    'Select': '#efc389'
-  }
-
-  return colors[material] || '#bc7e45'
-}
-
-function adjustColor(hex: string, factor: number): string {
-  const normalized = hex.replace('#', '')
-  if (normalized.length !== 6) {
-    return hex
-  }
-
-  const num = parseInt(normalized, 16)
-  let r = (num >> 16) & 0xff
-  let g = (num >> 8) & 0xff
-  let b = num & 0xff
-
-  const adjust = (value: number) => {
-    if (factor >= 0) {
-      return Math.min(255, Math.round(value + (255 - value) * factor))
-    }
-
-    return Math.max(0, Math.round(value + value * factor))
-  }
-
-  r = adjust(r)
-  g = adjust(g)
-  b = adjust(b)
-
-  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
 }
 

--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useMemo } from 'react'
+import { Edges } from '@react-three/drei'
 
 interface SkidModelProps {
   length: number
@@ -10,30 +11,34 @@ interface SkidModelProps {
 
 export function SkidModel({ length, position, material }: SkidModelProps) {
   const skidColor = useMemo(() => getSkidColor(material), [material])
-  
+  const edgeColor = '#b37b44'
+
   return (
     <group position={position}>
       {/* Skid runners (2 pieces) - 4x4 lumber */}
       <mesh position={[-1.75, 0, 0]} castShadow receiveShadow>
         <boxGeometry args={[3.5, 3.5, length]} />
         <meshLambertMaterial color={skidColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
-      
+
       <mesh position={[1.75, 0, 0]} castShadow receiveShadow>
         <boxGeometry args={[3.5, 3.5, length]} />
         <meshLambertMaterial color={skidColor} />
+        <Edges color={edgeColor} threshold={25} />
       </mesh>
-      
+
       {/* Cross members (every 16 inches) - 2x4 lumber */}
       {Array.from({ length: Math.floor(length / 16) + 1 }, (_, index) => (
-        <mesh 
+        <mesh
           key={index}
-          position={[0, 1.75, (index * 16) - length / 2]} 
-          castShadow 
+          position={[0, 1.75, (index * 16) - length / 2]}
+          castShadow
           receiveShadow
         >
           <boxGeometry args={[7, 1.5, 3.5]} />
           <meshLambertMaterial color={skidColor} />
+          <Edges color={edgeColor} threshold={25} />
         </mesh>
       ))}
     </group>
@@ -42,11 +47,11 @@ export function SkidModel({ length, position, material }: SkidModelProps) {
 
 function getSkidColor(material: string): string {
   const colors: Record<string, string> = {
-    'Standard': '#8B4513', // Brown
-    '#2': '#A0522D',       // Sienna
-    '#1': '#D2691E',       // Chocolate
-    'Select': '#F4A460'    // Sandy Brown
+    'Standard': '#bc7e45',
+    '#2': '#cc9359',
+    '#1': '#ddaa70',
+    'Select': '#efc389'
   }
-  
-  return colors[material] || '#8B4513'
+
+  return colors[material] || '#bc7e45'
 }

--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -11,7 +11,7 @@ interface SkidModelProps {
 
 export function SkidModel({ length, position, material }: SkidModelProps) {
   const skidColor = useMemo(() => getSkidColor(material), [material])
-  const edgeColor = '#b37b44'
+  const edgeColor = useMemo(() => adjustColor(skidColor, -0.25), [skidColor])
 
   return (
     <group position={position}>
@@ -55,3 +55,30 @@ function getSkidColor(material: string): string {
 
   return colors[material] || '#bc7e45'
 }
+
+function adjustColor(hex: string, factor: number): string {
+  const normalized = hex.replace('#', '')
+  if (normalized.length !== 6) {
+    return hex
+  }
+
+  const num = parseInt(normalized, 16)
+  let r = (num >> 16) & 0xff
+  let g = (num >> 8) & 0xff
+  let b = num & 0xff
+
+  const adjust = (value: number) => {
+    if (factor >= 0) {
+      return Math.min(255, Math.round(value + (255 - value) * factor))
+    }
+
+    return Math.max(0, Math.round(value + value * factor))
+  }
+
+  r = adjust(r)
+  g = adjust(g)
+  b = adjust(b)
+
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
+}
+

--- a/src/components/cad-viewer/utils/materialColors.ts
+++ b/src/components/cad-viewer/utils/materialColors.ts
@@ -1,0 +1,82 @@
+const DEFAULT_LUMBER_COLOR = '#c8894c'
+const DEFAULT_PLYWOOD_COLOR = '#e0c79c'
+
+const LUMBER_COLORS: Record<string, string> = {
+  Standard: '#c8894c',
+  '#2': '#d79b63',
+  '#1': '#e8ae78',
+  Select: '#f4c999'
+}
+
+const SKID_COLORS: Record<string, string> = {
+  Standard: '#bc7e45',
+  '#2': '#cc9359',
+  '#1': '#ddaa70',
+  Select: '#efc389'
+}
+
+const PANEL_BASE_COLORS: Record<string, string> = {
+  CDX: '#e6cc9f',
+  BC: '#eed7b0',
+  AC: '#f6e7c9',
+  Marine: '#f1d9a6',
+  OSB: '#d7b483',
+  Standard: '#c8894c',
+  '#2': '#d79b63',
+  '#1': '#e8ae78',
+  Select: '#f4c999'
+}
+
+const PANEL_TONES = {
+  bottom: -0.12,
+  top: 0.06,
+  side: -0.04,
+  end: -0.08
+} as const
+
+export type CratePanelType = keyof typeof PANEL_TONES
+
+export function getLumberColor(material: string): string {
+  return LUMBER_COLORS[material] || DEFAULT_LUMBER_COLOR
+}
+
+export function getSkidColor(material: string): string {
+  if (material in SKID_COLORS) {
+    return SKID_COLORS[material]
+  }
+
+  return adjustColor(getLumberColor(material), -0.08)
+}
+
+export function getPanelColor(material: string, type: CratePanelType): string {
+  const baseColor = PANEL_BASE_COLORS[material] || DEFAULT_PLYWOOD_COLOR
+  const tone = PANEL_TONES[type]
+
+  return adjustColor(baseColor, tone)
+}
+
+export function adjustColor(hex: string, factor: number): string {
+  const normalized = hex.replace('#', '')
+  if (normalized.length !== 6) {
+    return hex
+  }
+
+  const num = parseInt(normalized, 16)
+  let r = (num >> 16) & 0xff
+  let g = (num >> 8) & 0xff
+  let b = num & 0xff
+
+  const adjust = (value: number) => {
+    if (factor >= 0) {
+      return Math.min(255, Math.round(value + (255 - value) * factor))
+    }
+
+    return Math.max(0, Math.round(value + value * factor))
+  }
+
+  r = adjust(r)
+  g = adjust(g)
+  b = adjust(b)
+
+  return `#${((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1)}`
+}


### PR DESCRIPTION
## Summary
- reposition the camera to present an isometric, full-frame starting view of the crate and brighten the scene with a studio environment
- refresh crate framing, panels, and skid materials with lighter palettes and edge highlights so individual components are easier to read

## Testing
- `npm run lint` *(fails: existing lint violations in unrelated legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68c911eb720883298af1385bb72e355e