### PR TITLE
Refine skid calculations and automate configuration

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -89,7 +89,7 @@ EDGE_CONFIG=your_edge_config_id
 ### Basic Workflow
 1. **Configure Product**: Set product dimensions, weight, and center of gravity
 2. **Set Clearances**: Define internal clearances for handling
-3. **Configure Skids**: Set skid count, pitch, and overhang
+3. **Configure Skids**: Review auto-calculated skid count/spacing and adjust overhang
 4. **Select Materials**: Choose lumber grade, plywood, and hardware
 5. **Validate Design**: Review constraint validation and warnings
 6. **Optimize Materials**: Use AI-assisted optimization for cost/weight

--- a/seed/autocrate-enhanced-2025.md
+++ b/seed/autocrate-enhanced-2025.md
@@ -197,6 +197,8 @@ class ProductionNXGenerator implements NXExpressionGenerator {
     }
 
     // Generate expressions with Applied Materials standards
+    const skidRequirements = calculateSkidRequirements(config)
+
     const expressions: NXExpressionFile = {
       metadata: {
         generatedAt: new Date().toISOString(),
@@ -229,11 +231,11 @@ class ProductionNXGenerator implements NXExpressionGenerator {
 
       // Skid specifications with weight-based selection
       skidSpecs: {
-        skid_lumber_size_callout: this.selectSkidSize(config.product.weight),
-        skid_actual_height_in: this.getSkidDimensions(config).height,
-        skid_actual_width_in: this.getSkidDimensions(config).width,
-        skid_count: this.calculateSkidCount(config),
-        skid_pitch_in: this.calculateSkidPitch(config),
+        skid_lumber_size_callout: skidRequirements.lumberCallout,
+        skid_actual_height_in: skidRequirements.height,
+        skid_actual_width_in: skidRequirements.width,
+        skid_count: skidRequirements.count,
+        skid_pitch_in: skidRequirements.pitch,
         skid_overhang_front_in: config.skids.overhang.front,
         skid_overhang_back_in: config.skids.overhang.back
       },

--- a/src/app/api/export-pdf/route.ts
+++ b/src/app/api/export-pdf/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { CrateConfiguration, CrateDimensions } from '@/types/crate'
-import { calculateCrateDimensions, generateBillOfMaterials, calculateMaterialEfficiency, calculateCrateWeight } from '@/lib/domain/calculations'
+import { calculateCrateDimensions, generateBillOfMaterials, calculateMaterialEfficiency, calculateCrateWeight, calculateSkidRequirements } from '@/lib/domain/calculations'
 
 export async function POST(request: NextRequest) {
   try {
@@ -44,14 +44,15 @@ export async function POST(request: NextRequest) {
 }
 
 function generatePDFContent(
-  config: CrateConfiguration, 
-  dimensions: CrateDimensions, 
-  bom: { items: Array<{ id: string; description: string; quantity: number; unit: string; cost?: number }>; totalCost: number; materialWaste: number }, 
-  efficiency: number, 
+  config: CrateConfiguration,
+  dimensions: CrateDimensions,
+  bom: { items: Array<{ id: string; description: string; quantity: number; unit: string; cost?: number }>; totalCost: number; materialWaste: number },
+  efficiency: number,
   weight: number
 ) {
   const timestamp = new Date().toISOString()
   const filename = `autocrate_drawing_${timestamp.split('T')[0]}.pdf`
+  const skidRequirements = calculateSkidRequirements(config)
   
   // Generate PDF content structure (simplified)
   // In a real implementation, this would use a PDF generation library like jsPDF or Puppeteer
@@ -96,8 +97,9 @@ function generatePDFContent(
     
     // Skid configuration
     skids: {
-      count: config.skids.count,
-      pitch: config.skids.pitch,
+      count: skidRequirements.count,
+      pitch: skidRequirements.pitch,
+      lumberSize: skidRequirements.lumberCallout,
       frontOverhang: config.skids.overhang.front,
       backOverhang: config.skids.overhang.back
     },

--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -4,39 +4,20 @@ import { useMemo } from 'react'
 
 interface SkidModelProps {
   length: number
+  width: number
+  height: number
   position: [number, number, number]
   material: string
 }
 
-export function SkidModel({ length, position, material }: SkidModelProps) {
+export function SkidModel({ length, width, height, position, material }: SkidModelProps) {
   const skidColor = useMemo(() => getSkidColor(material), [material])
-  
+
   return (
-    <group position={position}>
-      {/* Skid runners (2 pieces) - 4x4 lumber */}
-      <mesh position={[-1.75, 0, 0]} castShadow receiveShadow>
-        <boxGeometry args={[3.5, 3.5, length]} />
-        <meshLambertMaterial color={skidColor} />
-      </mesh>
-      
-      <mesh position={[1.75, 0, 0]} castShadow receiveShadow>
-        <boxGeometry args={[3.5, 3.5, length]} />
-        <meshLambertMaterial color={skidColor} />
-      </mesh>
-      
-      {/* Cross members (every 16 inches) - 2x4 lumber */}
-      {Array.from({ length: Math.floor(length / 16) + 1 }, (_, index) => (
-        <mesh 
-          key={index}
-          position={[0, 1.75, (index * 16) - length / 2]} 
-          castShadow 
-          receiveShadow
-        >
-          <boxGeometry args={[7, 1.5, 3.5]} />
-          <meshLambertMaterial color={skidColor} />
-        </mesh>
-      ))}
-    </group>
+    <mesh position={position} castShadow receiveShadow>
+      <boxGeometry args={[width, height, length]} />
+      <meshLambertMaterial color={skidColor} />
+    </mesh>
   )
 }
 

--- a/src/components/design-studio/ConfigurationPanel.tsx
+++ b/src/components/design-studio/ConfigurationPanel.tsx
@@ -1,11 +1,13 @@
 'use client'
 
+import { useMemo } from 'react'
 import { useCrateStore, useCrateConfiguration } from '@/stores/crate-store'
-import { useFormFieldAccessibility } from '@/hooks/useAccessibility'
+import { calculateSkidRequirements } from '@/lib/domain/calculations'
 
 export function ConfigurationPanel() {
   const configuration = useCrateConfiguration()
   const updateConfiguration = useCrateStore(state => state.updateConfiguration)
+  const skidRequirements = useMemo(() => calculateSkidRequirements(configuration), [configuration])
   
   return (
     <div className="p-6 section-spacing">
@@ -147,35 +149,37 @@ export function ConfigurationPanel() {
         <div className="grid grid-cols-2 gap-4">
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Count
+              Count (auto)
             </label>
-            <input
-              type="number"
-              value={configuration.skids.count}
-              onChange={(e) => updateConfiguration({
-                skids: { ...configuration.skids, count: Number(e.target.value) }
-              })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
-              min="1"
-            />
+            <div className="w-full px-3 py-2 border border-gray-200 rounded-md bg-slate-50 text-slate-700">
+              {skidRequirements.count}
+            </div>
+            <p className="text-xs text-slate-500 mt-1">
+              Calculated from product weight and crate width.
+            </p>
           </div>
-          
+
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
-              Pitch (in)
+              Skid Spacing (in)
             </label>
-            <input
-              type="number"
-              value={configuration.skids.pitch}
-              onChange={(e) => updateConfiguration({
-                skids: { ...configuration.skids, pitch: Number(e.target.value) }
-              })}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
-              step="1"
-              min="12"
-            />
+            <div className="w-full px-3 py-2 border border-gray-200 rounded-md bg-slate-50 text-slate-700">
+              {skidRequirements.pitch.toFixed(2)}
+            </div>
+            <p className="text-xs text-slate-500 mt-1">
+              Maximum allowed spacing: {skidRequirements.maxSpacing}" center-to-center.
+            </p>
           </div>
-          
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              Lumber Size
+            </label>
+            <div className="w-full px-3 py-2 border border-gray-200 rounded-md bg-slate-50 text-slate-700">
+              {skidRequirements.lumberCallout}
+            </div>
+          </div>
+
           <div>
             <label className="block text-sm font-medium text-slate-700 mb-1">
               Front Overhang (in)

--- a/src/lib/domain/__tests__/calculations.test.ts
+++ b/src/lib/domain/__tests__/calculations.test.ts
@@ -23,17 +23,25 @@ describe('Crate Calculations', () => {
   })
   
   describe('calculateSkidRequirements', () => {
-    it('should calculate correct skid count for heavy products', () => {
-      const config = {
+    it('derives skid spacing and count from weight chart', () => {
+      const skids = calculateSkidRequirements(defaultCrateConfiguration)
+
+      expect(skids.lumberCallout).toBe('4x4')
+      expect(skids.count).toBe(3)
+      expect(skids.pitch).toBeCloseTo(20.75, 2)
+      expect(skids.length).toBe(57) // Overall length (53) + 2" front/back overhang
+    })
+
+    it('increases skid count when crate width grows beyond spacing limits', () => {
+      const wideConfig = {
         ...defaultCrateConfiguration,
-        product: { ...defaultCrateConfiguration.product, weight: 1500 }
+        product: { ...defaultCrateConfiguration.product, width: 80 }
       }
-      
-      const skids = calculateSkidRequirements(config)
-      
-      // 1500 lbs / 1000 lbs per skid = 2 skids required
-      expect(skids.count).toBe(2)
-      expect(skids.length).toBe(50) // 46 + 2 + 2 (product + overhangs)
+
+      const skids = calculateSkidRequirements(wideConfig)
+
+      expect(skids.count).toBeGreaterThan(3)
+      expect(skids.pitch).toBeLessThanOrEqual(skids.maxSpacing)
     })
   })
   

--- a/src/lib/domain/__tests__/nx-expression-generator.test.ts
+++ b/src/lib/domain/__tests__/nx-expression-generator.test.ts
@@ -46,12 +46,12 @@ describe('NXExpressionGenerator', () => {
 
     it('should select appropriate skid size based on weight', async () => {
       const lightConfig = { ...defaultCrateConfiguration, product: { ...defaultCrateConfiguration.product, weight: 300 } }
-      const heavyConfig = { ...defaultCrateConfiguration, product: { ...defaultCrateConfiguration.product, weight: 1500 } }
+      const heavyConfig = { ...defaultCrateConfiguration, product: { ...defaultCrateConfiguration.product, weight: 5000 } }
 
       const lightExpressions = await generator.generateExpressions(lightConfig)
       const heavyExpressions = await generator.generateExpressions(heavyConfig)
 
-      expect(lightExpressions.skidSpecs.skid_lumber_size_callout).toBe('2x4')
+      expect(lightExpressions.skidSpecs.skid_lumber_size_callout).toBe('4x4')
       expect(heavyExpressions.skidSpecs.skid_lumber_size_callout).toBe('4x6')
     })
 
@@ -135,9 +135,9 @@ describe('NXExpressionGenerator', () => {
           ...defaultCrateConfiguration.product, 
           length: 200, 
           width: 200, 
-          height: 200, 
-          weight: 5000 
-        } 
+          height: 200,
+          weight: 25000
+        }
       }
       
       const expressions = await generator.generateExpressions(largeConfig)

--- a/src/lib/nx/nx-expression-generator.ts
+++ b/src/lib/nx/nx-expression-generator.ts
@@ -78,33 +78,6 @@ export class NXExpressionGenerator {
     return Math.abs(hash).toString(16)
   }
 
-  private selectSkidSize(weight: number): string {
-    if (weight < 500) return '2x4'
-    if (weight < 1000) return '4x4'
-    if (weight < 2000) return '4x6'
-    return '6x6'
-  }
-
-  private getSkidDimensions(config: CrateConfiguration): { width: number; height: number } {
-    const skidSize = this.selectSkidSize(config.product.weight)
-    const dimensions: Record<string, { width: number; height: number }> = {
-      '2x4': { width: 3.5, height: 1.5 },
-      '4x4': { width: 3.5, height: 3.5 },
-      '4x6': { width: 5.5, height: 3.5 },
-      '6x6': { width: 5.5, height: 5.5 }
-    }
-    return dimensions[skidSize] || { width: 3.5, height: 3.5 }
-  }
-
-  private calculateSkidCount(config: CrateConfiguration): number {
-    const skidRequirements = calculateSkidRequirements(config)
-    return skidRequirements.count
-  }
-
-  private calculateSkidPitch(config: CrateConfiguration): number {
-    return config.skids.pitch
-  }
-
   private generatePanelSpecifications(config: CrateConfiguration) {
     const panels = calculatePanelRequirements(config)
     
@@ -164,7 +137,7 @@ export class NXExpressionGenerator {
   }
 
   async generateExpressions(config: CrateConfiguration): Promise<NXExpressionFile> {
-    const skidDimensions = this.getSkidDimensions(config)
+    const skidRequirements = calculateSkidRequirements(config)
 
     const expressions: NXExpressionFile = {
       metadata: {
@@ -198,11 +171,11 @@ export class NXExpressionGenerator {
 
       // Skid specifications with weight-based selection
       skidSpecs: {
-        skid_lumber_size_callout: this.selectSkidSize(config.product.weight),
-        skid_actual_height_in: skidDimensions.height,
-        skid_actual_width_in: skidDimensions.width,
-        skid_count: this.calculateSkidCount(config),
-        skid_pitch_in: this.calculateSkidPitch(config),
+        skid_lumber_size_callout: skidRequirements.lumberCallout,
+        skid_actual_height_in: skidRequirements.height,
+        skid_actual_width_in: skidRequirements.width,
+        skid_count: skidRequirements.count,
+        skid_pitch_in: skidRequirements.pitch,
         skid_overhang_front_in: config.skids.overhang.front,
         skid_overhang_back_in: config.skids.overhang.back
       },

--- a/src/lib/step-processor/pmi-annotations.ts
+++ b/src/lib/step-processor/pmi-annotations.ts
@@ -1,5 +1,6 @@
 import { CrateConfiguration, CrateDimensions } from '@/types/crate'
 import { PMIAnnotations, DimensionAnnotation, GeometricTolerance, ManufacturingNote, DatumFeature } from './step-types'
+import { calculateSkidRequirements } from '@/lib/domain/calculations'
 
 export function generatePMIAnnotations(config: CrateConfiguration, dimensions: CrateDimensions): PMIAnnotations {
   const annotations: PMIAnnotations = {
@@ -223,6 +224,7 @@ function generateGeometricTolerances(config: CrateConfiguration, dimensions: Cra
 
 function generateManufacturingNotes(config: CrateConfiguration, dimensions: CrateDimensions): ManufacturingNote[] {
   const notes: ManufacturingNote[] = []
+  const skidRequirements = calculateSkidRequirements(config)
 
   // Material specifications note
   notes.push({
@@ -249,7 +251,7 @@ function generateManufacturingNotes(config: CrateConfiguration, dimensions: Crat
   notes.push({
     id: 'NOTE_ASSEMBLY_INSTRUCTIONS',
     text: `ASSEMBLY INSTRUCTIONS:
-1. Install skids with ${config.skids.count} count at ${config.skids.pitch}" pitch
+1. Install skids with ${skidRequirements.count} count at ${skidRequirements.pitch.toFixed(2)}" pitch
 2. Front overhang: ${config.skids.overhang.front}", Back overhang: ${config.skids.overhang.back}"
 3. Fasten with lag screws per Applied Materials standard
 4. Verify clearances: W=${config.clearances.width}", L=${config.clearances.length}", H=${config.clearances.height}"`,

--- a/src/types/crate.ts
+++ b/src/types/crate.ts
@@ -171,8 +171,8 @@ export const defaultCrateConfiguration: CrateConfiguration = {
       front: 2,
       back: 2
     },
-    count: 1,
-    pitch: 16
+    count: 3,
+    pitch: 20.75
   },
   materials: {
     lumber: {


### PR DESCRIPTION
## Summary
- implement an Applied Materials skid sizing table and compute count, spacing, and lumber callouts automatically while updating BOM output to use the derived dimensions
- refresh the 3D model, metadata, and configuration panel to display the auto-calculated skid layout and remove manual controls for count/pitch
- propagate the derived skid data through the store, NX/PDF exports, PMI annotations, and default configuration so downstream consumers stay in sync

## Testing
- npm test -- --runInBand *(fails: suite includes Playwright/Jest conflicts in upstream tests)*
- npm test -- src/lib/domain/__tests__/calculations.test.ts --runInBand
- npm test -- src/lib/domain/__tests__/nx-expression-generator.test.ts --runInBand

------
https://chatgpt.com/codex/tasks/task_e_68c90e290e708329af89ffd7cd7a6b58