### PR TITLE
Fix mobile touch handling

### DIFF
--- a/src/components/cad-viewer/CrateVisualizer.tsx
+++ b/src/components/cad-viewer/CrateVisualizer.tsx
@@ -110,7 +110,13 @@ export const CrateVisualizer = memo(function CrateVisualizer({
   )
 
   return (
-    <div className={`${className} ${getMobileClasses()}`} role="img" aria-label="3D Crate Visualization" tabIndex={0}>
+    <div
+      className={`${className} ${getMobileClasses()}`}
+      role="img"
+      aria-label="3D Crate Visualization"
+      tabIndex={0}
+      data-touch-interactive="true"
+    >
       <Canvas
         camera={{
           position: cameraPosition,


### PR DESCRIPTION
## Summary
- scope the mobile gesture handler so only touches that originate from the 3D viewer block native events
- filter tracked touch points to avoid capturing interactions outside the viewer while keeping gesture support intact
- label the visualizer container as touch-interactive so mobile gestures continue to work without hijacking the rest of the UI

## Testing
- npm run lint *(fails: existing repository lint violations)*

------
https://chatgpt.com/codex/tasks/task_e_68c98c506100832990b4820455b93747