### PR TITLE
Fix skid geometry and model cleat requirements

### DIFF
--- a/src/components/cad-viewer/SkidModel.tsx
+++ b/src/components/cad-viewer/SkidModel.tsx
@@ -7,6 +7,9 @@ import { adjustColor, getSkidColor } from './utils/materialColors'
 
 interface SkidModelProps {
   length: number
+  runnerWidth: number
+  runnerHeight: number
+  floorboardThickness: number
   position: [number, number, number]
   material: string
   metadataId?: string
@@ -17,6 +20,9 @@ interface SkidModelProps {
 
 export function SkidModel({
   length,
+  runnerWidth,
+  runnerHeight,
+  floorboardThickness,
   position,
   material,
   metadataId,
@@ -26,47 +32,63 @@ export function SkidModel({
 }: SkidModelProps) {
   const skidColor = useMemo(() => getSkidColor(material), [material])
   const edgeColor = useMemo(() => adjustColor(skidColor, -0.25), [skidColor])
+  const runnerOffsetX = runnerWidth / 2
+  const crossMemberCount = useMemo(() => Math.max(2, Math.ceil(length / 16) + 1), [length])
+  const crossMemberDepth = runnerWidth
+  const crossMemberWidth = runnerWidth * 2
+  const crossMemberStart = useMemo(() => -length / 2 + crossMemberDepth / 2, [length, crossMemberDepth])
+  const crossMemberStep = useMemo(() => {
+    if (crossMemberCount <= 1) {
+      return 0
+    }
+
+    return (length - crossMemberDepth) / (crossMemberCount - 1)
+  }, [crossMemberCount, length, crossMemberDepth])
 
   return (
     <group position={position}>
       {/* Skid runners (2 pieces) - 4x4 lumber */}
       <mesh
-        position={[-1.75, 0, 0]}
+        position={[-runnerOffsetX, 0, 0]}
         castShadow
         receiveShadow
         onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
         onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
         onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
       >
-        <boxGeometry args={[3.5, 3.5, length]} />
+        <boxGeometry args={[runnerWidth, runnerHeight, length]} />
         <meshLambertMaterial color={skidColor} />
         <Edges color={edgeColor} threshold={25} />
       </mesh>
       <mesh
-        position={[1.75, 0, 0]}
+        position={[runnerOffsetX, 0, 0]}
         castShadow
         receiveShadow
         onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
         onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
         onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
       >
-        <boxGeometry args={[3.5, 3.5, length]} />
+        <boxGeometry args={[runnerWidth, runnerHeight, length]} />
         <meshLambertMaterial color={skidColor} />
         <Edges color={edgeColor} threshold={25} />
       </mesh>
 
       {/* Cross members (every 16 inches) - 2x4 lumber */}
-      {Array.from({ length: Math.floor(length / 16) + 1 }, (_, index) => (
+      {Array.from({ length: crossMemberCount }, (_, index) => (
         <mesh
           key={index}
-          position={[0, 1.75, (index * 16) - length / 2]}
+          position={[
+            0,
+            runnerHeight / 2 + floorboardThickness / 2,
+            crossMemberStart + index * crossMemberStep
+          ]}
           castShadow
           receiveShadow
           onPointerOver={metadataId ? event => onPointerOver?.(metadataId, event) : undefined}
           onPointerMove={metadataId ? event => onPointerMove?.(metadataId, event) : undefined}
           onPointerOut={metadataId ? event => onPointerOut?.(metadataId, event) : undefined}
         >
-          <boxGeometry args={[7, 1.5, 3.5]} />
+          <boxGeometry args={[crossMemberWidth, floorboardThickness, crossMemberDepth]} />
           <meshLambertMaterial color={skidColor} />
           <Edges color={edgeColor} threshold={25} />
         </mesh>

--- a/src/components/cad-viewer/__tests__/PMIAnnotations.test.tsx
+++ b/src/components/cad-viewer/__tests__/PMIAnnotations.test.tsx
@@ -13,7 +13,15 @@ jest.mock('../../../lib/domain/calculations', () => ({
     internalWidth: 47,
     internalLength: 42,
     internalHeight: 93.5
-  }))
+  })),
+  generateBillOfMaterials: jest.fn(() => ({
+    items: [],
+    totalCost: 0,
+    materialWaste: 10,
+    generatedAt: new Date()
+  })),
+  calculateMaterialEfficiency: jest.fn(() => 90),
+  calculateCrateWeight: jest.fn(() => 850)
 }))
 
 // Mock the Html component from drei

--- a/src/lib/domain/__tests__/calculations.test.ts
+++ b/src/lib/domain/__tests__/calculations.test.ts
@@ -33,7 +33,7 @@ describe('Crate Calculations', () => {
 
       // 1500 lbs / 1000 lbs per skid = 2 skids required
       expect(skids.count).toBe(2)
-      expect(skids.length).toBe(50) // 46 + 2 + 2 (product + overhangs)
+      expect(skids.length).toBe(57) // Overall length 53 + 2" front + 2" back overhangs
     })
 
 


### PR DESCRIPTION
## Summary
- correct skid dimension logic to return runner height, extend length to match overall crate dimensions, and compute cleat counts when side panels are spliced
- reposition skid assemblies and bottom structures in the 3D crate assembly and skid model so floorboards sit beneath the bottom panel, and expose cleat information in component metadata/BOM
- update related unit tests and PMI annotation mocks to reflect the new skid length and domain utilities

## Testing
- `npm test -- --watch=false` *(fails: existing Jest suites reference unavailable STEP exporter modules and Playwright tests that must be run separately)*
- `npm run type-check` *(fails: baseline repo lacks Jest type definitions and includes Playwright/Jest config conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_68c98bc6aab48329bcf4453fe08fba40