### PR TITLE
Guard crate store persistence for SSR environments

### DIFF
--- a/src/stores/crate-store.ts
+++ b/src/stores/crate-store.ts
@@ -75,6 +75,11 @@ const validateStandardsCompliance = (config: CrateConfiguration): ValidationResu
   return validateCrateConfiguration(config)
 }
 
+const storage =
+  typeof window !== 'undefined'
+    ? createJSONStorage(() => window.localStorage)
+    : undefined
+
 export const useCrateStore = create<CrateStore>()(
   persist(
     (set, get) => ({
@@ -206,8 +211,8 @@ export const useCrateStore = create<CrateStore>()(
     }),
     {
       name: 'autocrate-store',
-      storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ 
+      ...(storage ? { storage } : {}),
+      partialize: (state) => ({
         configuration: state.configuration,
         viewport: state.viewport 
       }),


### PR DESCRIPTION
## Summary
- Guard the crate store persistence initializer so that `localStorage` is only referenced when the browser APIs are available.
- Keep the existing rehydration behavior by reusing the same storage initializer once the client loads.

## Testing
- npm run dev
- curl -I http://localhost:3000/

------
https://chatgpt.com/codex/tasks/task_e_68ca4d61ae3883299920155922fac721