### PR TITLE
Add lumber cut list view to replace plywood tab

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import CrateVisualizer from '@/components/CrateVisualizer'
 import { NXGenerator, CrateConfig } from '@/lib/nx-generator'
-import { PlywoodPieceSelector } from '@/components/PlywoodPieceSelector'
+import { LumberCutList } from '@/components/LumberCutList'
 
 export default function Home() {
   // Store input values as strings for better input handling
@@ -63,21 +63,8 @@ export default function Home() {
   })
 
   const [generator, setGenerator] = useState<NXGenerator>(() => new NXGenerator(config))
-  const [activeTab, setActiveTab] = useState<'visualization' | 'expressions' | 'bom' | 'plywood'>('visualization')
+  const [activeTab, setActiveTab] = useState<'visualization' | 'expressions' | 'bom' | 'lumber'>('visualization')
   const [showMobileInputs, setShowMobileInputs] = useState(false)
-  // Initialize all plywood pieces as visible by default
-  const [plywoodPieceVisibility, setPlywoodPieceVisibility] = useState<Record<string, boolean>>(() => {
-    const initial: Record<string, boolean> = {}
-    // Set all plywood pieces to visible by default
-    for (let i = 1; i <= 6; i++) {
-      initial[`FRONT_PANEL_PLY_${i}`] = true
-      initial[`BACK_PANEL_PLY_${i}`] = true
-      initial[`LEFT_END_PANEL_PLY_${i}`] = true
-      initial[`RIGHT_END_PANEL_PLY_${i}`] = true
-      initial[`TOP_PANEL_PLY_${i}`] = true
-    }
-    return initial
-  })
   const debounceTimeoutRef = useRef<{ [key: string]: NodeJS.Timeout }>({})
 
   // Update generator when config changes or 3x4 lumber permission changes
@@ -213,8 +200,6 @@ export default function Home() {
         if (box.panelName === 'LEFT_END_PANEL' && !displayOptions.visibility.leftPanel) return false
         if (box.panelName === 'RIGHT_END_PANEL' && !displayOptions.visibility.rightPanel) return false
         if (box.panelName === 'TOP_PANEL' && !displayOptions.visibility.topPanel) return false
-        // Check individual piece visibility (default to true if not set)
-        if (plywoodPieceVisibility[box.name] === false) return false
         return true
       }
 
@@ -227,13 +212,6 @@ export default function Home() {
 
       return true
     })
-  }
-
-  const handlePlywoodPieceToggle = (pieceName: string) => {
-    setPlywoodPieceVisibility(prev => ({
-      ...prev,
-      [pieceName]: !prev[pieceName]
-    }))
   }
 
   return (
@@ -495,14 +473,14 @@ export default function Home() {
                 BOM
               </button>
               <button
-                onClick={() => setActiveTab('plywood')}
+                onClick={() => setActiveTab('lumber')}
                 className={`px-4 py-2 text-sm font-medium ${
-                  activeTab === 'plywood'
+                  activeTab === 'lumber'
                     ? 'border-b-2 border-blue-500 text-blue-600'
                     : 'text-gray-500 hover:text-gray-700'
                 }`}
               >
-                Plywood Pieces
+                Lumber Cut List
               </button>
             </nav>
           </div>
@@ -553,12 +531,9 @@ export default function Home() {
               </div>
             )}
 
-            {activeTab === 'plywood' && (
+            {activeTab === 'lumber' && (
               <div className="h-full overflow-auto">
-                <PlywoodPieceSelector
-                  boxes={generator.getBoxes()}
-                  onPieceToggle={handlePlywoodPieceToggle}
-                />
+                <LumberCutList cutList={generator.generateCutList()} />
               </div>
             )}
           </div>

--- a/src/components/LumberCutList.tsx
+++ b/src/components/LumberCutList.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { LumberCutList as LumberCutListData } from '@/lib/nx-generator'
+
+interface LumberCutListProps {
+  cutList: LumberCutListData
+}
+
+const formatNumber = (value: number) => {
+  const rounded = Math.round(value * 100) / 100
+  if (Math.abs(rounded - Math.round(rounded)) < 0.01) {
+    return Math.round(rounded).toString()
+  }
+  if (Math.abs(rounded - Math.round(rounded * 10) / 10) < 0.01) {
+    return (Math.round(rounded * 10) / 10).toFixed(1)
+  }
+  return rounded.toFixed(2)
+}
+
+const formatInches = (value: number) => `${formatNumber(value)}"`
+const formatFeet = (value: number) => `${formatNumber(value)} ft`
+
+const formatPanelName = (panel: string) =>
+  panel
+    .toLowerCase()
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ')
+
+const formatCleatTypes = (types: string[]) =>
+  types
+    .map(type => type.charAt(0).toUpperCase() + type.slice(1))
+    .join(', ')
+
+export function LumberCutList({ cutList }: LumberCutListProps) {
+  return (
+    <div className="space-y-6 text-sm">
+      <section>
+        <h2 className="text-base font-semibold text-gray-900 mb-3">Skids</h2>
+        <div className="overflow-hidden rounded-lg border border-gray-200">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Material</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Cut Length</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Qty</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {cutList.skids.map((item, index) => (
+                <tr key={`skid-${index}`}>
+                  <td className="px-3 py-2">{item.material}</td>
+                  <td className="px-3 py-2">{formatInches(item.length)}</td>
+                  <td className="px-3 py-2">{item.count}</td>
+                  <td className="px-3 py-2 text-gray-500">{item.notes ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-base font-semibold text-gray-900 mb-3">Floorboards</h2>
+        <div className="overflow-hidden rounded-lg border border-gray-200">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Material</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Cut Length</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Qty</th>
+                <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Notes</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {cutList.floorboards.map((item, index) => (
+                <tr key={`floor-${index}`}>
+                  <td className="px-3 py-2">{item.material}</td>
+                  <td className="px-3 py-2">{formatInches(item.length)}</td>
+                  <td className="px-3 py-2">{item.count}</td>
+                  <td className="px-3 py-2 text-gray-500">{item.notes ?? '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-base font-semibold text-gray-900">Cleats</h2>
+          <span className="text-xs text-gray-500">
+            Total: {formatFeet(cutList.summary.cleatLinearFeet)} • Est. 1x4 boards: {cutList.summary.cleatBoardCount}
+          </span>
+        </div>
+        <p className="text-xs text-gray-500 mb-3">All cleats use 1x4 lumber (0.75" × 3.5"). Cut pieces per panel as listed below.</p>
+        <div className="space-y-4">
+          {cutList.cleats.map(panel => (
+            <div key={panel.panel} className="overflow-hidden rounded-lg border border-gray-200">
+              <div className="bg-gray-50 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                {formatPanelName(panel.panel)}
+              </div>
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Orientation</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Cut Length</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Qty</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Cleat Type</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {panel.items.map((item, index) => (
+                    <tr key={`${panel.panel}-${index}`}>
+                      <td className="px-3 py-2">{item.orientation === 'horizontal' ? 'Horizontal' : 'Vertical'}</td>
+                      <td className="px-3 py-2">{formatInches(item.length)}</td>
+                      <td className="px-3 py-2">{item.count}</td>
+                      <td className="px-3 py-2 text-gray-500">{formatCleatTypes(item.types)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section>
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-base font-semibold text-gray-900">Plywood Panels</h2>
+          <span className="text-xs text-gray-500">
+            Total sheets: {cutList.summary.totalPlywoodSheets} • Thickness: {formatInches(cutList.summary.plywoodThickness)}
+          </span>
+        </div>
+        <p className="text-xs text-gray-500 mb-3">Cut plywood sections for each panel. Dimensions are shown as width × height.</p>
+        <div className="space-y-4">
+          {cutList.plywood.map(panel => (
+            <div key={panel.panel} className="overflow-hidden rounded-lg border border-gray-200">
+              <div className="bg-gray-50 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                {formatPanelName(panel.panel)}
+              </div>
+              <div className="px-3 py-2 text-xs text-gray-500 border-b border-gray-200">
+                Sheets required: {panel.sheetCount}{' '}
+                {panel.isRotated ? '• Rotated 90° orientation' : '• Standard orientation'}
+              </div>
+              <table className="w-full text-sm">
+                <thead className="bg-gray-50">
+                  <tr>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Piece Size</th>
+                    <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">Qty</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200">
+                  {panel.pieces.map((piece, index) => (
+                    <tr key={`${panel.panel}-piece-${index}`}>
+                      <td className="px-3 py-2">{formatInches(piece.width)} × {formatInches(piece.height)}</td>
+                      <td className="px-3 py-2">{piece.count}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace the plywood tab with a lumber cut list that calls out skids, floorboards, cleats, and plywood pieces with their cut lengths
- add cut list generation utilities to the NX generator so UI consumers can render grouped lumber data
- introduce a LumberCutList component that formats the cut instructions for customers

## Testing
- npm run build *(fails: Next.js cannot download the Inter font in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc779ac0c8329b44d9c4155593117